### PR TITLE
Fix FileProvider manifest merging issue

### DIFF
--- a/pluto/src/main/AndroidManifest.xml
+++ b/pluto/src/main/AndroidManifest.xml
@@ -13,7 +13,7 @@
             android:theme="@style/PlutoTheme.NoActionBar" />
 
         <provider
-            android:name="androidx.core.content.FileProvider"
+            android:name=".core.PlutoFileProvider"
             android:authorities="pluto___${applicationId}.provider"
             android:exported="false"
             android:grantUriPermissions="true">

--- a/pluto/src/main/java/com/mocklets/pluto/core/PlutoFileProvider.kt
+++ b/pluto/src/main/java/com/mocklets/pluto/core/PlutoFileProvider.kt
@@ -1,0 +1,5 @@
+package com.mocklets.pluto.core
+
+import androidx.core.content.FileProvider
+
+internal class PlutoFileProvider : FileProvider()


### PR DESCRIPTION
When attempting to use Pluto in an app that already has its own `FileProvider` entry in the manifest the app will fail to build during the manifest merger stage. This PR creates a simple subclass of `FileProvider` for Pluto to use in it's manifest which prevents this issue.

Error:
```
/Users/hibob224/Documents/AndroidStudio/pluto/sample/src/main/AndroidManifest.xml:17:13-51 Error:
	Attribute provider#androidx.core.content.FileProvider@authorities value=(com.sampleapp) from AndroidManifest.xml:17:13-51
	is also present at [:pluto] AndroidManifest.xml:21:13-68 value=(pluto___com.sampleapp.provider).
	Suggestion: add 'tools:replace="android:authorities"' to <provider> element at AndroidManifest.xml:15:9-23:20 to override.
/Users/hibob224/Documents/AndroidStudio/pluto/sample/src/main/AndroidManifest.xml:22:17-51 Error:
	Attribute meta-data#android.support.FILE_PROVIDER_PATHS@resource value=(@xml/file_paths) from AndroidManifest.xml:22:17-51
	is also present at [:pluto] AndroidManifest.xml:26:17-68 value=(@xml/pluto___file_provider_paths).
	Suggestion: add 'tools:replace="android:resource"' to <meta-data> element at AndroidManifest.xml:20:13-22:54 to override.
```

Issue repro branch: https://github.com/hibob224/pluto/tree/manifest_merger_issue
Reference: https://commonsware.com/blog/2017/06/27/fileprovider-libraries.html

