### PR TITLE
Fix shared prefs setting description

### DIFF
--- a/pluto/src/main/res/layout/pluto___item_settings_shared_pref.xml
+++ b/pluto/src/main/res/layout/pluto___item_settings_shared_pref.xml
@@ -30,7 +30,7 @@
         android:layout_marginBottom="@dimen/pluto___margin_large"
         android:ellipsize="end"
         android:fontFamily="@font/muli"
-        android:text="@string/pluto___easy_access_setup_description"
+        android:text="@string/pluto___settings_shared_pref_description"
         android:textColor="@color/pluto___text_dark_40"
         android:textSize="@dimen/pluto___text_small"
         app:layout_constraintBottom_toBottomOf="parent"

--- a/pluto/src/main/res/values/strings.xml
+++ b/pluto/src/main/res/values/strings.xml
@@ -63,6 +63,7 @@
     <string name="pluto___settings_clear_crashes_title">Clear all crash logs</string>
     <string name="pluto___update">Update</string>
     <string name="pluto___settings_shared_pref_title">Show Shared Preference for</string>
+    <string name="pluto___settings_shared_pref_description">Configure which Shared Preference files are displayed in the Shared Preferences tab.</string>
     <string name="pluto___settings_link_mocklets_title">Link Mocklets Account</string>
     <string name="pluto___link">Link</string>
     <string name="pluto___settings_link_mocklets_description">Connect you Mocklets account to manage your network proxy setting efficiently</string>


### PR DESCRIPTION
* Shared prefs row in settings was sharing a description with the easy access toggle, created a new description.