### PR TITLE
Add new method to Pluto to open the Ui without clicking the notification

### DIFF
--- a/pluto-no-op/src/main/java/com/mocklets/pluto/Pluto.kt
+++ b/pluto-no-op/src/main/java/com/mocklets/pluto/Pluto.kt
@@ -15,4 +15,6 @@ object Pluto {
     fun setExceptionHandler(uncaughtExceptionHandler: Thread.UncaughtExceptionHandler) {}
 
     fun setANRListener(listener: ANRListener) {}
+
+    fun showUi() {}
 }

--- a/pluto/src/main/java/com/mocklets/pluto/Pluto.kt
+++ b/pluto/src/main/java/com/mocklets/pluto/Pluto.kt
@@ -2,6 +2,7 @@ package com.mocklets.pluto
 
 import android.app.Application
 import android.content.Context
+import android.content.Intent
 import androidx.annotation.Keep
 import com.mocklets.pluto.core.Session
 import com.mocklets.pluto.core.preferences.Preferences
@@ -11,6 +12,7 @@ import com.mocklets.pluto.modules.exceptions.ExceptionRepo
 import com.mocklets.pluto.modules.exceptions.anrs.AnrSupervisor
 import com.mocklets.pluto.modules.exceptions.crashes.CrashHandler
 import com.mocklets.pluto.modules.network.proxy.NetworkProxyRepo
+import com.mocklets.pluto.ui.PlutoActivity
 
 @Keep
 object Pluto {
@@ -56,5 +58,15 @@ object Pluto {
 
     fun setANRListener(listener: ANRListener) {
         anrSupervisor.setListener(listener)
+    }
+
+    fun showUi() {
+        val context =
+            appContext ?: throw IllegalStateException("cannot open Ui as Pluto is not initialised.")
+        val intent = Intent(context, PlutoActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+        context.startActivity(intent)
     }
 }


### PR DESCRIPTION
On Android TV it is not possible to open the Ui using the notification. It was possible before to send an intent to start PlutoActivity, but now it is internal and not exposed to the apps that use the library. So I added a method to give the user the opportunity to launch the activity programmatically