### PR TITLE
Add support for configurable main thread response threshold

### DIFF
--- a/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/PlutoExceptions.kt
+++ b/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/PlutoExceptions.kt
@@ -3,6 +3,7 @@ package com.pluto.plugins.exceptions
 import android.content.Context
 import com.pluto.plugins.exceptions.internal.Session
 import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor
+import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.DEFAULT_MAIN_THREAD_RESPONSE_THRESHOLD
 import com.pluto.plugins.exceptions.internal.crash.CrashHandler
 import com.pluto.plugins.exceptions.internal.persistence.ExceptionDBHandler
 
@@ -14,6 +15,12 @@ object PlutoExceptions {
         private set
     internal val session = Session()
     internal lateinit var appPackageName: String
+
+    /**
+     * The threshold for main thread response
+     * time before resulting in ANR.
+     */
+    var mainThreadResponseThreshold = DEFAULT_MAIN_THREAD_RESPONSE_THRESHOLD
 
     internal fun initialize(context: Context, identifier: String) {
         appPackageName = context.packageName

--- a/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/anr/AnrSupervisor.kt
+++ b/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/anr/AnrSupervisor.kt
@@ -49,6 +49,6 @@ internal class AnrSupervisor {
         const val LOGTAG = "Pluto-ANR-watcher"
         const val ANR_WATCHER_THREAD_NAME = "pluto-anr-watcher"
         const val ANR_WATCHER_TIMEOUT: Long = 10_000
-        const val MAIN_THREAD_RESPONSE_THRESHOLD: Long = 2_000
+        const val DEFAULT_MAIN_THREAD_RESPONSE_THRESHOLD: Long = 2_000
     }
 }

--- a/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/anr/AnrSupervisorRunnable.kt
+++ b/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/anr/AnrSupervisorRunnable.kt
@@ -4,13 +4,13 @@ import android.os.Handler
 import android.os.Looper
 import com.pluto.plugin.utilities.DebugLog
 import com.pluto.plugins.exceptions.ANRException
+import com.pluto.plugins.exceptions.PlutoExceptions
 import com.pluto.plugins.exceptions.UncaughtANRHandler
 import com.pluto.plugins.exceptions.internal.ExceptionAllData
 import com.pluto.plugins.exceptions.internal.ThreadStates
 import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.ANR_WATCHER_THREAD_NAME
 import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.ANR_WATCHER_TIMEOUT
 import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.LOGTAG
-import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.MAIN_THREAD_RESPONSE_THRESHOLD
 import com.pluto.plugins.exceptions.internal.asExceptionData
 import com.pluto.plugins.exceptions.internal.asThreadData
 import com.pluto.plugins.exceptions.internal.extensions.wait
@@ -56,7 +56,7 @@ internal class AnrSupervisorRunnable : Runnable {
                 // Perform test, Handler should run the callback within 1s
                 synchronized(callback) {
                     mHandler.post(callback)
-                    callback.wait(MAIN_THREAD_RESPONSE_THRESHOLD)
+                    callback.wait(PlutoExceptions.mainThreadResponseThreshold)
 
                     // Check if called
                     if (!callback.isCalled) {
@@ -101,7 +101,7 @@ internal class AnrSupervisorRunnable : Runnable {
     @Throws(InterruptedException::class)
     private fun checkStopped() {
         if (mStopped) {
-            Thread.sleep(MAIN_THREAD_RESPONSE_THRESHOLD)
+            Thread.sleep(PlutoExceptions.mainThreadResponseThreshold)
             if (mStopped) {
                 throw InterruptedException()
             }

--- a/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/holder/CrashItemDetailsHeaderHolder.kt
+++ b/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/holder/CrashItemDetailsHeaderHolder.kt
@@ -8,10 +8,10 @@ import com.pluto.plugin.utilities.list.DiffAwareAdapter
 import com.pluto.plugin.utilities.list.DiffAwareHolder
 import com.pluto.plugin.utilities.list.ListItem
 import com.pluto.plugin.utilities.spannable.setSpan
+import com.pluto.plugins.exceptions.PlutoExceptions
 import com.pluto.plugins.exceptions.R
 import com.pluto.plugins.exceptions.databinding.PlutoExcepItemCrashDetailsHeaderBinding
 import com.pluto.plugins.exceptions.internal.ExceptionData
-import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.MAIN_THREAD_RESPONSE_THRESHOLD
 
 internal class CrashItemDetailsHeaderHolder(
     parent: ViewGroup,
@@ -66,7 +66,7 @@ internal class CrashItemDetailsHeaderHolder(
     private fun handleTitle(item: ExceptionData) {
         if (item.isANRException) {
             message.text =
-                context.getString(R.string.pluto_excep___anr_list_message, MAIN_THREAD_RESPONSE_THRESHOLD)
+                context.getString(R.string.pluto_excep___anr_list_message, PlutoExceptions.mainThreadResponseThreshold)
             title.setSpan {
                 context.apply {
                     append(

--- a/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/holder/CrashItemHolder.kt
+++ b/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/holder/CrashItemHolder.kt
@@ -9,9 +9,9 @@ import com.pluto.plugin.utilities.list.DiffAwareHolder
 import com.pluto.plugin.utilities.list.ListItem
 import com.pluto.plugin.utilities.setOnDebounceClickListener
 import com.pluto.plugin.utilities.spannable.setSpan
+import com.pluto.plugins.exceptions.PlutoExceptions
 import com.pluto.plugins.exceptions.R
 import com.pluto.plugins.exceptions.databinding.PlutoExcepItemCrashBinding
-import com.pluto.plugins.exceptions.internal.anr.AnrSupervisor.Companion.MAIN_THREAD_RESPONSE_THRESHOLD
 import com.pluto.plugins.exceptions.internal.persistence.ExceptionEntity
 
 internal class CrashItemHolder(
@@ -27,7 +27,7 @@ internal class CrashItemHolder(
             with(item.data.exception) {
                 if (isANRException) {
                     binding.message.text =
-                        context.getString(R.string.pluto_excep___anr_list_message, MAIN_THREAD_RESPONSE_THRESHOLD)
+                        context.getString(R.string.pluto_excep___anr_list_message, PlutoExceptions.mainThreadResponseThreshold)
                     binding.title.setSpan {
                         context.apply {
                             append(


### PR DESCRIPTION
This would allow developers to set a custom threshold time for reporting ANRs.