### PR TITLE
fix(crashadapter-leak) : Clear reference of crashAdapter after fragment is destroyed

### DIFF
--- a/pluto-plugins/base/lib/src/main/java/com/pluto/utilities/AutoClearedValue.kt
+++ b/pluto-plugins/base/lib/src/main/java/com/pluto/utilities/AutoClearedValue.kt
@@ -44,7 +44,6 @@ private open class AutoClearedValue<T : Any>(protected val fragment: Fragment) :
         })
     }
 
-
     override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
         return value
             ?: throw IllegalStateException("should never call auto-cleared-value get when it might not be available")

--- a/pluto-plugins/base/lib/src/main/java/com/pluto/utilities/AutoClearedValue.kt
+++ b/pluto-plugins/base/lib/src/main/java/com/pluto/utilities/AutoClearedValue.kt
@@ -75,7 +75,7 @@ private class AutoClearedInitializedValue<T:Any>(fragment: Fragment, private val
     }
 }
 
-fun <T : Any> Fragment.autoCleared(initializerFactory: () -> T) = AutoClearedInitializedValue(this, initializerFactory) as ReadOnlyProperty<Fragment, T>
+fun <T : Any> Fragment.autoClearInitializer(initializerFactory: () -> T) = AutoClearedInitializedValue(this, initializerFactory) as ReadOnlyProperty<Fragment, T>
 
 fun <T : ViewBinding> Fragment.viewBinding(viewBindingFactory: (View) -> T) =
     FragmentViewBindingDelegate(this, viewBindingFactory) as ReadOnlyProperty<Fragment, T>

--- a/pluto-plugins/base/lib/src/main/java/com/pluto/utilities/FragmentViewBindingDelegate.kt
+++ b/pluto-plugins/base/lib/src/main/java/com/pluto/utilities/FragmentViewBindingDelegate.kt
@@ -21,7 +21,7 @@ class FragmentViewBindingDelegate<T : ViewBinding>(val fragment: Fragment, val v
     init {
         fragment.lifecycle.addObserver(object : DefaultLifecycleObserver {
             val viewLifecycleOwnerLiveDataObserver =
-                Observer<LifecycleOwner?> {
+                Observer<LifecycleOwner> {
                     val viewLifecycleOwner = it ?: return@Observer
 
                     viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
@@ -42,17 +42,13 @@ class FragmentViewBindingDelegate<T : ViewBinding>(val fragment: Fragment, val v
     }
 
     override fun getValue(thisRef: Fragment, property: KProperty<*>): T {
-        val binding = binding
-        if (binding != null) {
-            return binding
-        }
 
         val lifecycle = fragment.viewLifecycleOwner.lifecycle
         check(lifecycle.currentState.isAtLeast(Lifecycle.State.INITIALIZED)) {
             "Should not attempt to get bindings when Fragment views are destroyed."
         }
 
-        return viewBindingFactory(thisRef.requireView()).also { this.binding = it }
+        return binding ?: viewBindingFactory(thisRef.requireView()).also { this.binding = it }
     }
 }
 

--- a/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/DetailsFragment.kt
+++ b/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/DetailsFragment.kt
@@ -16,6 +16,7 @@ import com.pluto.plugins.exceptions.R
 import com.pluto.plugins.exceptions.databinding.PlutoExcepFragmentDetailsBinding
 import com.pluto.plugins.exceptions.internal.ReportData
 import com.pluto.plugins.exceptions.internal.persistence.ExceptionEntity
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.capitalizeText
 import com.pluto.utilities.extensions.delayedLaunchWhenResumed
 import com.pluto.utilities.extensions.onBackPressed
@@ -36,7 +37,7 @@ internal class DetailsFragment : Fragment(R.layout.pluto_excep___fragment_detail
 
     private val binding by viewBinding(PlutoExcepFragmentDetailsBinding::bind)
     private val viewModel: CrashesViewModel by activityViewModels()
-    private val crashAdapter: BaseAdapter by lazy { CrashesAdapter(onActionListener) }
+    private val crashAdapter: BaseAdapter by autoClearInitializer { CrashesAdapter(onActionListener) }
     private val exceptionCipher by lazy { getCipheredException() }
     private val contentSharer by lazyContentSharer()
 

--- a/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ListFragment.kt
@@ -14,6 +14,7 @@ import com.pluto.plugins.exceptions.PlutoExceptions
 import com.pluto.plugins.exceptions.R
 import com.pluto.plugins.exceptions.databinding.PlutoExcepFragmentListBinding
 import com.pluto.plugins.exceptions.internal.persistence.ExceptionEntity
+import com.pluto.utilities.autoCleared
 import com.pluto.utilities.extensions.hideKeyboard
 import com.pluto.utilities.extensions.linearLayoutManager
 import com.pluto.utilities.extensions.showMoreOptions
@@ -30,11 +31,12 @@ class ListFragment : Fragment(R.layout.pluto_excep___fragment_list) {
 
     private val binding by viewBinding(PlutoExcepFragmentListBinding::bind)
     private val viewModel: CrashesViewModel by activityViewModels()
-    private val crashAdapter: BaseAdapter by lazy { CrashesAdapter(onActionListener) }
+    private var crashAdapter by autoCleared<BaseAdapter>()
     private var isFetchingInProgress: Boolean = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        crashAdapter = CrashesAdapter(onActionListener)
         binding.crashList.apply {
             adapter = crashAdapter
             addItemDecoration(CustomItemDecorator(requireContext()))

--- a/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ListFragment.kt
@@ -31,12 +31,13 @@ class ListFragment : Fragment(R.layout.pluto_excep___fragment_list) {
 
     private val binding by viewBinding(PlutoExcepFragmentListBinding::bind)
     private val viewModel: CrashesViewModel by activityViewModels()
-    private var crashAdapter by autoCleared<BaseAdapter>()
+    private val crashAdapter by autoCleared<BaseAdapter>{
+        CrashesAdapter(onActionListener)
+    }
     private var isFetchingInProgress: Boolean = false
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        crashAdapter = CrashesAdapter(onActionListener)
         binding.crashList.apply {
             adapter = crashAdapter
             addItemDecoration(CustomItemDecorator(requireContext()))

--- a/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ListFragment.kt
@@ -14,7 +14,7 @@ import com.pluto.plugins.exceptions.PlutoExceptions
 import com.pluto.plugins.exceptions.R
 import com.pluto.plugins.exceptions.databinding.PlutoExcepFragmentListBinding
 import com.pluto.plugins.exceptions.internal.persistence.ExceptionEntity
-import com.pluto.utilities.autoCleared
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.hideKeyboard
 import com.pluto.utilities.extensions.linearLayoutManager
 import com.pluto.utilities.extensions.showMoreOptions
@@ -31,7 +31,7 @@ class ListFragment : Fragment(R.layout.pluto_excep___fragment_list) {
 
     private val binding by viewBinding(PlutoExcepFragmentListBinding::bind)
     private val viewModel: CrashesViewModel by activityViewModels()
-    private val crashAdapter by autoCleared<BaseAdapter>{
+    private val crashAdapter by autoClearInitializer<BaseAdapter> {
         CrashesAdapter(onActionListener)
     }
     private var isFetchingInProgress: Boolean = false

--- a/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ThreadStackTraceFragment.kt
+++ b/pluto-plugins/plugins/exceptions/lib/src/main/java/com/pluto/plugins/exceptions/internal/ui/ThreadStackTraceFragment.kt
@@ -14,6 +14,7 @@ import com.pluto.plugins.exceptions.internal.ProcessThread
 import com.pluto.plugins.exceptions.internal.ThreadStates
 import com.pluto.plugins.exceptions.internal.persistence.ExceptionEntity
 import com.pluto.plugins.exceptions.internal.ui.holder.StackTraceListItemHolder
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.onBackPressed
 import com.pluto.utilities.extensions.showMoreOptions
 import com.pluto.utilities.list.BaseAdapter
@@ -29,7 +30,7 @@ import com.pluto.utilities.viewBinding
 class ThreadStackTraceFragment : Fragment(R.layout.pluto_excep___fragment_thread_stack_trace) {
     private val binding by viewBinding(PlutoExcepFragmentThreadStackTraceBinding::bind)
     private val viewModel: CrashesViewModel by activityViewModels()
-    private val threadAdapter: BaseAdapter by lazy { StackTracesAdapter(onActionListener) }
+    private val threadAdapter: BaseAdapter by autoClearInitializer { StackTracesAdapter(onActionListener) }
     private var linearLayoutManager: LinearLayoutManager = LinearLayoutManager(context, RecyclerView.VERTICAL, false)
     private val contentSharer by lazyContentSharer()
     private var filterValue: String? = null

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/attributes/ViewAttrFragment.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/attributes/ViewAttrFragment.kt
@@ -19,6 +19,7 @@ import com.pluto.plugins.layoutinspector.internal.inspect.clearTargetTag
 import com.pluto.plugins.layoutinspector.internal.inspect.findViewByTargetTag
 import com.pluto.plugins.layoutinspector.internal.inspect.getFrontView
 import com.pluto.plugins.layoutinspector.internal.inspect.getIdString
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.device.Device
 import com.pluto.utilities.extensions.color
 import com.pluto.utilities.list.BaseAdapter
@@ -40,7 +41,9 @@ internal class ViewAttrFragment : BottomSheetDialogFragment() {
     private val binding by viewBinding(PlutoLiFragmentViewAttrBinding::bind)
     private val contentSharer: ContentShareViewModel by lazyContentSharer()
     private var targetView: View? = null
-    private lateinit var attributeAdapter: BaseAdapter
+    private val attributeAdapter: BaseAdapter by autoClearInitializer {
+        AttributeAdapter(onActionListener)
+    }
     private val viewModel: ViewAttrViewModel by viewModels()
     private val keyValuePairEditor: KeyValuePairEditor by lazyKeyValuePairEditor()
 
@@ -78,7 +81,6 @@ internal class ViewAttrFragment : BottomSheetDialogFragment() {
             }
         }
         targetView?.let { target ->
-            attributeAdapter = AttributeAdapter(onActionListener)
             binding.close.setOnDebounceClickListener {
                 dismiss()
             }

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/hierarchy/ViewHierarchyFragment.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/hierarchy/ViewHierarchyFragment.kt
@@ -20,6 +20,7 @@ import com.pluto.plugins.layoutinspector.internal.hierarchy.list.HierarchyItemHo
 import com.pluto.plugins.layoutinspector.internal.inspect.InspectViewModel
 import com.pluto.plugins.layoutinspector.internal.inspect.assignTargetTag
 import com.pluto.plugins.layoutinspector.internal.inspect.getFrontView
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.onBackPressed
 import com.pluto.utilities.extensions.toast
 import com.pluto.utilities.list.BaseAdapter
@@ -32,7 +33,9 @@ import com.pluto.utilities.viewBinding
 internal class ViewHierarchyFragment : DialogFragment() {
 
     private var rootView: View? = null
-    private lateinit var hierarchyAdapter: BaseAdapter
+    private val hierarchyAdapter: BaseAdapter by autoClearInitializer {
+        HierarchyAdapter(onActionListener)
+    }
     private val viewModel: ViewHierarchyViewModel by viewModels()
     private val inspectViewModel: InspectViewModel by activityViewModels()
     private val binding by viewBinding(PlutoLiFragmentViewHierarchyBinding::bind)
@@ -66,7 +69,6 @@ internal class ViewHierarchyFragment : DialogFragment() {
             binding.collapseCta.setOnDebounceClickListener {
                 viewModel.collapseAll(it)
             }
-            hierarchyAdapter = HierarchyAdapter(onActionListener)
             binding.list.apply {
                 adapter = hierarchyAdapter
             }

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/hint/HintFragment.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/hint/HintFragment.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Observer
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.pluto.plugins.layoutinspector.R
 import com.pluto.plugins.layoutinspector.databinding.PlutoLiHintFragmentBinding
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.dp
 import com.pluto.utilities.list.BaseAdapter
 import com.pluto.utilities.list.CustomItemDecorator
@@ -17,7 +18,7 @@ import com.pluto.utilities.viewBinding
 internal class HintFragment : BottomSheetDialogFragment() {
 
     private val binding by viewBinding(PlutoLiHintFragmentBinding::bind)
-    private val settingsAdapter: BaseAdapter by lazy { HintAdapter() }
+    private val settingsAdapter: BaseAdapter by autoClearInitializer { HintAdapter() }
     private val viewModel: HintViewModel by activityViewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =

--- a/pluto-plugins/plugins/logger/lib/src/main/java/com/pluto/plugins/logger/internal/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/logger/lib/src/main/java/com/pluto/plugins/logger/internal/ui/ListFragment.kt
@@ -15,6 +15,7 @@ import com.pluto.plugins.logger.internal.LogsRepo
 import com.pluto.plugins.logger.internal.LogsViewModel
 import com.pluto.plugins.logger.internal.Session
 import com.pluto.plugins.logger.internal.ui.list.LogsAdapter
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.hideKeyboard
 import com.pluto.utilities.extensions.linearLayoutManager
 import com.pluto.utilities.extensions.showMoreOptions
@@ -33,7 +34,7 @@ internal class ListFragment : Fragment(R.layout.pluto_logger___fragment_list) {
 
     private val binding by viewBinding(PlutoLoggerFragmentListBinding::bind)
     private val viewModel: LogsViewModel by activityViewModels()
-    private val logsAdapter: BaseAdapter by lazy { LogsAdapter(onActionListener) }
+    private val logsAdapter: BaseAdapter by autoClearInitializer { LogsAdapter(onActionListener) }
     private val contentSharer by lazyContentSharer()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -68,7 +69,7 @@ internal class ListFragment : Fragment(R.layout.pluto_logger___fragment_list) {
                 when (item.itemId) {
                     R.id.clear -> LogsRepo.deleteAll()
                     R.id.shareAll ->
-                        if (viewModel.logs.value?.size ?: 0 > 0) {
+                        if ((viewModel.logs.value?.size ?: 0) > 0) {
                             viewModel.serializeLogs()
                         } else {
                             context?.toast("No logs to share")

--- a/pluto-plugins/plugins/logger/lib/src/main/java/com/pluto/plugins/logger/internal/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/logger/lib/src/main/java/com/pluto/plugins/logger/internal/ui/ListFragment.kt
@@ -69,7 +69,7 @@ internal class ListFragment : Fragment(R.layout.pluto_logger___fragment_list) {
                 when (item.itemId) {
                     R.id.clear -> LogsRepo.deleteAll()
                     R.id.shareAll ->
-                        if ((viewModel.logs.value?.size ?: 0) > 0) {
+                        if (viewModel.logs.value?.size ?: 0 > 0) {
                             viewModel.serializeLogs()
                         } else {
                             context?.toast("No logs to share")

--- a/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/ListFragment.kt
@@ -16,6 +16,7 @@ import com.pluto.plugins.network.internal.interceptor.logic.ApiCallData
 import com.pluto.plugins.network.internal.interceptor.logic.NetworkCallsRepo
 import com.pluto.plugins.network.internal.interceptor.ui.DetailsFragment.Companion.API_CALL_ID
 import com.pluto.plugins.network.internal.interceptor.ui.list.NetworkAdapter
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.hideKeyboard
 import com.pluto.utilities.extensions.linearLayoutManager
 import com.pluto.utilities.extensions.showMoreOptions
@@ -31,11 +32,12 @@ internal class ListFragment : Fragment(R.layout.pluto_network___fragment_list) {
 
     private val binding by viewBinding(PlutoNetworkFragmentListBinding::bind)
     private val viewModel: NetworkViewModel by activityViewModels()
-    private lateinit var networkAdapter: BaseAdapter
+    private val networkAdapter: BaseAdapter by autoClearInitializer {
+        NetworkAdapter(onActionListener)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        networkAdapter = NetworkAdapter(onActionListener)
         binding.apiList.apply {
             adapter = networkAdapter
             addItemDecoration(CustomItemDecorator(requireContext()))

--- a/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/mock/ui/MockSettingsListFragment.kt
+++ b/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/mock/ui/MockSettingsListFragment.kt
@@ -14,6 +14,7 @@ import com.pluto.plugins.network.R
 import com.pluto.plugins.network.databinding.PlutoNetworkFragmentMockSettingsListBinding
 import com.pluto.plugins.network.internal.mock.logic.dao.MockSettingsEntity
 import com.pluto.plugins.network.internal.mock.ui.list.MockSettingsItemAdapter
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.dp
 import com.pluto.utilities.extensions.hideKeyboard
 import com.pluto.utilities.extensions.onBackPressed
@@ -30,12 +31,13 @@ internal class MockSettingsListFragment : Fragment(R.layout.pluto_network___frag
 
     private val binding by viewBinding(PlutoNetworkFragmentMockSettingsListBinding::bind)
     private val viewModel: MockSettingsViewModel by activityViewModels()
-    private lateinit var mockSettingsAdapter: BaseAdapter
+    private val mockSettingsAdapter: BaseAdapter by autoClearInitializer {
+        MockSettingsItemAdapter(onActionListener)
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         onBackPressed { handleBackPress() }
-        mockSettingsAdapter = MockSettingsItemAdapter(onActionListener)
         binding.apiList.apply {
             adapter = mockSettingsAdapter
             addItemDecoration(CustomItemDecorator(context, DECORATOR_DIVIDER_PADDING))

--- a/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/share/ShareFragment.kt
+++ b/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/share/ShareFragment.kt
@@ -14,6 +14,7 @@ import com.pluto.plugins.network.internal.interceptor.logic.responseToText
 import com.pluto.plugins.network.internal.interceptor.logic.toShareText
 import com.pluto.plugins.network.internal.interceptor.ui.DetailContentData
 import com.pluto.plugins.network.internal.interceptor.ui.NetworkViewModel
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.list.BaseAdapter
 import com.pluto.utilities.list.CustomItemDecorator
 import com.pluto.utilities.list.DiffAwareAdapter
@@ -28,7 +29,7 @@ class ShareFragment : BottomSheetDialogFragment() {
     private val binding by viewBinding(PlutoNetworkFragmentShareBinding::bind)
     private val detailsViewModel: NetworkViewModel by activityViewModels()
     private val shareViewModel: ShareOptionsViewModel by viewModels()
-    private lateinit var optionAdapter: BaseAdapter
+    private val optionAdapter: BaseAdapter by autoClearInitializer { ShareOptionsAdapter(onActionListener) }
     private val contentSharer by lazyContentSharer()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
@@ -38,7 +39,6 @@ class ShareFragment : BottomSheetDialogFragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        optionAdapter = ShareOptionsAdapter(onActionListener)
         binding.shareOptionsList.apply {
             adapter = optionAdapter
             addItemDecoration(CustomItemDecorator(requireContext()))

--- a/pluto-plugins/plugins/shared-preferences/lib/src/main/java/com/pluto/plugins/preferences/ui/ListFragment.kt
+++ b/pluto-plugins/plugins/shared-preferences/lib/src/main/java/com/pluto/plugins/preferences/ui/ListFragment.kt
@@ -14,6 +14,7 @@ import com.pluto.plugins.preferences.SharedPrefRepo
 import com.pluto.plugins.preferences.databinding.PlutoPrefFragmentListBinding
 import com.pluto.plugins.preferences.ui.EditProcessor.Companion.fromEditorData
 import com.pluto.plugins.preferences.ui.EditProcessor.Companion.toEditorData
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.hideKeyboard
 import com.pluto.utilities.extensions.linearLayoutManager
 import com.pluto.utilities.extensions.showMoreOptions
@@ -34,7 +35,7 @@ internal class ListFragment : Fragment(R.layout.pluto_pref___fragment_list) {
     private val binding by viewBinding(PlutoPrefFragmentListBinding::bind)
     private val viewModel: SharedPrefViewModel by activityViewModels()
     private val keyValuePairEditor: KeyValuePairEditor by lazyKeyValuePairEditor()
-    private val prefAdapter: BaseAdapter by lazy { SharedPrefAdapter(onActionListener) }
+    private val prefAdapter: BaseAdapter by autoClearInitializer { SharedPrefAdapter(onActionListener) }
     private val contentSharer by lazyContentSharer()
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {

--- a/pluto-plugins/plugins/shared-preferences/lib/src/main/java/com/pluto/plugins/preferences/ui/filter/FilterFragment.kt
+++ b/pluto-plugins/plugins/shared-preferences/lib/src/main/java/com/pluto/plugins/preferences/ui/filter/FilterFragment.kt
@@ -16,6 +16,7 @@ import com.pluto.plugins.preferences.getSharePreferencesFiles
 import com.pluto.plugins.preferences.ui.SharedPrefAdapter
 import com.pluto.plugins.preferences.ui.SharedPrefFile
 import com.pluto.plugins.preferences.ui.SharedPrefViewModel
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.device.Device
 import com.pluto.utilities.extensions.dp
 import com.pluto.utilities.extensions.toast
@@ -32,7 +33,7 @@ internal class FilterFragment : BottomSheetDialogFragment() {
     private val binding by viewBinding(PlutoPrefFragmentFilterBinding::bind)
     private val viewModel: SharedPrefViewModel by activityViewModels()
 
-    private val prefAdapter: BaseAdapter by lazy { SharedPrefAdapter(onActionListener) }
+    private val prefAdapter: BaseAdapter by autoClearInitializer { SharedPrefAdapter(onActionListener) }
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =
         inflater.inflate(R.layout.pluto_pref___fragment_filter, container, false)

--- a/pluto/lib/src/main/java/com/pluto/settings/SettingsFragment.kt
+++ b/pluto/lib/src/main/java/com/pluto/settings/SettingsFragment.kt
@@ -12,6 +12,7 @@ import com.pluto.R
 import com.pluto.databinding.PlutoFragmentSettingsBinding
 import com.pluto.settings.holders.SettingsGridSizeHolder.Companion.DEC_SIZE
 import com.pluto.settings.holders.SettingsGridSizeHolder.Companion.INC_SIZE
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.dp
 import com.pluto.utilities.extensions.openOverlaySettings
 import com.pluto.utilities.extensions.toast
@@ -26,7 +27,7 @@ import com.pluto.utilities.viewBinding
 internal class SettingsFragment : BottomSheetDialogFragment() {
 
     private val binding by viewBinding(PlutoFragmentSettingsBinding::bind)
-    private val settingsAdapter: BaseAdapter by lazy { SettingsAdapter(onActionListener) }
+    private val settingsAdapter: BaseAdapter by autoClearInitializer { SettingsAdapter(onActionListener) }
     private val viewModel: SettingsViewModel by activityViewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =

--- a/pluto/lib/src/main/java/com/pluto/tool/modules/ruler/internal/hint/HintFragment.kt
+++ b/pluto/lib/src/main/java/com/pluto/tool/modules/ruler/internal/hint/HintFragment.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.Observer
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import com.pluto.R
 import com.pluto.databinding.PlutoToolRulerHintFragmentBinding
+import com.pluto.utilities.autoClearInitializer
 import com.pluto.utilities.extensions.dp
 import com.pluto.utilities.list.BaseAdapter
 import com.pluto.utilities.list.CustomItemDecorator
@@ -17,7 +18,7 @@ import com.pluto.utilities.viewBinding
 internal class HintFragment : BottomSheetDialogFragment() {
 
     private val binding by viewBinding(PlutoToolRulerHintFragmentBinding::bind)
-    private val settingsAdapter: BaseAdapter by lazy { HintAdapter() }
+    private val settingsAdapter: BaseAdapter by autoClearInitializer { HintAdapter() }
     private val viewModel: HintViewModel by activityViewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View =

--- a/sample/src/main/java/com/sampleapp/functions/network/DemoNetworkFragment.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/DemoNetworkFragment.kt
@@ -5,7 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import androidx.lifecycle.ViewModelProvider
+import androidx.fragment.app.viewModels
 import com.pluto.plugins.network.BodyMediaSubType
 import com.pluto.plugins.network.BodyMediaType
 import com.pluto.plugins.network.CustomBody
@@ -23,7 +23,7 @@ class DemoNetworkFragment : Fragment(R.layout.fragment_demo_network) {
     private val binding
         get() = _binding!!
 
-    private val networkViewModel by lazy { ViewModelProvider(this)[NetworkViewModel::class.java] }
+    private val networkViewModel : NetworkViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentDemoNetworkBinding.inflate(inflater, container, false)

--- a/sample/src/main/java/com/sampleapp/functions/network/DemoNetworkFragment.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/DemoNetworkFragment.kt
@@ -23,7 +23,7 @@ class DemoNetworkFragment : Fragment(R.layout.fragment_demo_network) {
     private val binding
         get() = _binding!!
 
-    private val networkViewModel : NetworkViewModel by viewModels()
+    private val networkViewModel: NetworkViewModel by viewModels()
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentDemoNetworkBinding.inflate(inflater, container, false)


### PR DESCRIPTION
Clear adapter reference once the fragment is destroyed.
To do this, I have modified the FragmentViewBindingDelegate class to accommodate all types of variables and not just binding.

Fixes #207 

Let me know If I should continue working on this PR, basically modify all the adapters to use 'autoCleared'

