### PR TITLE
feature: GraphQL support (issue #326)

### DIFF
--- a/pluto-plugins/plugins/network/core/lib-no-op/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
+++ b/pluto-plugins/plugins/network/core/lib-no-op/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
@@ -11,6 +11,7 @@ class NetworkData {
     )
 
     data class Response(
+        val request: Request,
         val statusCode: Int,
         val body: Body?,
         val headers: Map<String, String?>,

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
@@ -16,7 +16,7 @@ class NetworkData {
     ) {
         data class GraphqlData(
             val queryType: String,
-            val queryNameWithVariables: String,
+            val queryName: String,
         )
 
         val graphqlData: GraphqlData? = parseGraphqlData()
@@ -29,17 +29,12 @@ class NetworkData {
             ) return null
             val json = runCatching { JSONObject(body!!.body.toString()) }.getOrNull() ?: return null
             val query = json.optString("query") ?: return null
-            val variables = json.optJSONObject("variables")
             val match = graqphlQueryRegex.find(query)?.groupValues ?: return null
             return GraphqlData(
                 queryType = match[1],
-                queryNameWithVariables = match[2] + variables?.formatVariables().orEmpty(),
+                queryName = match[2],
             )
         }
-
-        private fun JSONObject.formatVariables() =
-            keys().asSequence().joinToString { "$it: ${get(it)}" }.let { " ($it)" }
-
 
         internal val isGzipped: Boolean
             get() = headers["Content-Encoding"].equals("gzip", ignoreCase = true)

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
@@ -50,7 +50,7 @@ class NetworkData {
         val protocol: String = "",
         val fromDiskCache: Boolean = false,
     ) {
-        val hasGraphqlErrors = parseHasGraphqlError()
+        val hasGraphqlErrors = parseHasGraphqlErrors()
 
         internal val status: Status
             get() = Status(statusCode, getStatusMessage())
@@ -62,7 +62,7 @@ class NetworkData {
         private fun getStatusMessage() = mapCode2Message(statusCode) +
                 if (hasGraphqlErrors) ", Response with errors" else ""
 
-        private fun parseHasGraphqlError(): Boolean {
+        private fun parseHasGraphqlErrors(): Boolean {
             if (request.graphqlData == null ||
                 body == null ||
                 body.isBinary ||

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/intercept/NetworkData.kt
@@ -3,6 +3,7 @@ package com.pluto.plugins.network.intercept
 import com.pluto.plugins.network.internal.Status
 import com.pluto.plugins.network.internal.interceptor.logic.mapCode2Message
 import io.ktor.http.ContentType
+import org.json.JSONObject
 
 class NetworkData {
 
@@ -11,32 +12,70 @@ class NetworkData {
         val method: String,
         val body: Body?,
         val headers: Map<String, String?>,
-        val sentTimestamp: Long
+        val sentTimestamp: Long,
     ) {
+        data class GraphqlData(
+            val queryType: String,
+            val queryName: String,
+        )
+
+        val graphqlData: GraphqlData? = parseGraphqlData()
+
+        private fun parseGraphqlData(): GraphqlData? {
+            if (method != "POST" ||
+                body == null ||
+                body.isBinary ||
+                !body.body.startsWith("{")
+            ) return null
+            val json = runCatching { JSONObject(body!!.body.toString()) }.getOrNull() ?: return null
+            val query = json.optString("query") ?: return null
+            val match = graqphlQueryRegex.find(query)?.groupValues ?: return null
+            return GraphqlData(
+                queryType = match[1],
+                queryName = match[2],
+            )
+        }
+
         internal val isGzipped: Boolean
             get() = headers["Content-Encoding"].equals("gzip", ignoreCase = true)
     }
 
     data class Response(
+        val request: Request,
         private val statusCode: Int,
         val body: Body?,
         val headers: Map<String, String?>,
         val sentTimestamp: Long,
         val receiveTimestamp: Long,
         val protocol: String = "",
-        val fromDiskCache: Boolean = false
+        val fromDiskCache: Boolean = false,
     ) {
+        val hasGraphqlErrors = parseHasGraphqlError()
+
         internal val status: Status
-            get() = Status(statusCode, mapCode2Message(statusCode))
+            get() = Status(statusCode, getStatusMessage())
         val isSuccessful: Boolean
-            get() = statusCode in 200..299
+            get() = statusCode in 200..299 && !hasGraphqlErrors
         internal val isGzipped: Boolean
             get() = headers["Content-Encoding"].equals("gzip", ignoreCase = true)
+
+        private fun getStatusMessage() = mapCode2Message(statusCode) +
+                if (hasGraphqlErrors) ", Response with errors" else ""
+
+        private fun parseHasGraphqlError(): Boolean {
+            if (request.graphqlData == null ||
+                body == null ||
+                body.isBinary ||
+                !body.body.startsWith("{")
+            ) return false
+            val json = runCatching { JSONObject(body!!.body.toString()) }.getOrNull() ?: return false
+            return json.has("errors")
+        }
     }
 
     data class Body(
         val body: CharSequence,
-        val contentType: String
+        val contentType: String,
     ) {
         private val contentTypeInternal: ContentType = ContentType.parse(contentType)
         private val mediaType: String = contentTypeInternal.contentType
@@ -48,5 +87,6 @@ class NetworkData {
 
     companion object {
         internal val BINARY_MEDIA_TYPES = listOf("audio", "video", "image", "font")
+        private val graqphlQueryRegex = Regex("""\b(query|mutation)\s+(\w+)""")
     }
 }

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
@@ -40,7 +40,7 @@ internal class ApiItemHolder(parent: ViewGroup, actionListener: DiffAwareAdapter
             binding.root.setBackgroundColor(context.color(R.color.pluto___transparent))
 
             val method = (item.request.graphqlData?.queryType ?: item.request.method).uppercase()
-            val urlOrQuery = item.request.graphqlData?.queryName ?: Url(item.request.url).encodedPath
+            val urlOrQuery = item.request.graphqlData?.queryNameWithVariables ?: Url(item.request.url).encodedPath
             graphqlIcon.isVisible = item.request.graphqlData != null
 
             url.setSpan {

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
@@ -40,7 +40,7 @@ internal class ApiItemHolder(parent: ViewGroup, actionListener: DiffAwareAdapter
             binding.root.setBackgroundColor(context.color(R.color.pluto___transparent))
 
             val method = (item.request.graphqlData?.queryType ?: item.request.method).uppercase()
-            val urlOrQuery = item.request.graphqlData?.queryNameWithVariables ?: Url(item.request.url).encodedPath
+            val urlOrQuery = item.request.graphqlData?.queryName ?: Url(item.request.url).encodedPath
             graphqlIcon.isVisible = item.request.graphqlData != null
 
             url.setSpan {

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
@@ -4,6 +4,7 @@ import android.view.View.GONE
 import android.view.View.INVISIBLE
 import android.view.View.VISIBLE
 import android.view.ViewGroup
+import androidx.core.view.isVisible
 import com.pluto.plugins.network.R
 import com.pluto.plugins.network.databinding.PlutoNetworkItemNetworkBinding
 import com.pluto.plugins.network.intercept.NetworkData.Response
@@ -30,6 +31,7 @@ internal class ApiItemHolder(parent: ViewGroup, actionListener: DiffAwareAdapter
     private val error = binding.error
     private val timeElapsed = binding.timeElapsed
     private val proxyIndicator = binding.proxyIndicator
+    private val graphqlIcon = binding.graphqlIcon
 
     override fun onBind(item: ListItem) {
         if (item is ApiCallData) {
@@ -37,9 +39,13 @@ internal class ApiItemHolder(parent: ViewGroup, actionListener: DiffAwareAdapter
             timeElapsed.text = item.request.sentTimestamp.asTimeElapsed()
             binding.root.setBackgroundColor(context.color(R.color.pluto___transparent))
 
+            val method = (item.request.graphqlData?.queryType ?: item.request.method).uppercase()
+            val urlOrQuery = item.request.graphqlData?.queryName ?: Url(item.request.url).encodedPath
+            graphqlIcon.isVisible = item.request.graphqlData != null
+
             url.setSpan {
-                append(fontColor(item.request.method.uppercase(), context.color(R.color.pluto___text_dark_60)))
-                append("  ${Url(item.request.url).encodedPath}")
+                append(fontColor(method, context.color(R.color.pluto___text_dark_60)))
+                append("  ${urlOrQuery}")
             }
             progress.visibility = VISIBLE
             status.visibility = INVISIBLE

--- a/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
+++ b/pluto-plugins/plugins/network/core/lib/src/main/java/com/pluto/plugins/network/internal/interceptor/ui/list/ApiItemHolder.kt
@@ -45,7 +45,7 @@ internal class ApiItemHolder(parent: ViewGroup, actionListener: DiffAwareAdapter
 
             url.setSpan {
                 append(fontColor(method, context.color(R.color.pluto___text_dark_60)))
-                append("  ${urlOrQuery}")
+                append("  $urlOrQuery")
             }
             progress.visibility = VISIBLE
             status.visibility = INVISIBLE

--- a/pluto-plugins/plugins/network/core/lib/src/main/res/drawable/pluto_network___ic_graphql.xml
+++ b/pluto-plugins/plugins/network/core/lib/src/main/res/drawable/pluto_network___ic_graphql.xml
@@ -1,0 +1,51 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="400"
+    android:viewportHeight="400">
+  <path
+      android:pathData="M57.47,302.66l-14.38,-8.3l160.15,-277.38l14.38,8.3z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M39.8,272.2h320.3v16.6h-320.3z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M206.35,374.03l-160.21,-92.5l8.3,-14.38l160.21,92.5z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M345.52,132.95l-160.21,-92.5l8.3,-14.38l160.21,92.5z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M54.48,132.88l-8.3,-14.38l160.21,-92.5l8.3,14.38z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M342.57,302.66l-160.15,-277.38l14.38,-8.3l160.15,277.38z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M52.5,107.5h16.6v185h-16.6z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M330.9,107.5h16.6v185h-16.6z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M203.52,367l-7.25,-12.56l139.34,-80.45l7.25,12.56z"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M369.5,297.9c-9.6,16.7 -31,22.4 -47.7,12.8c-16.7,-9.6 -22.4,-31 -12.8,-47.7c9.6,-16.7 31,-22.4 47.7,-12.8C373.5,259.9 379.2,281.2 369.5,297.9"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M90.9,137c-9.6,16.7 -31,22.4 -47.7,12.8c-16.7,-9.6 -22.4,-31 -12.8,-47.7c9.6,-16.7 31,-22.4 47.7,-12.8C94.8,99 100.5,120.3 90.9,137"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M30.5,297.9c-9.6,-16.7 -3.9,-38 12.8,-47.7c16.7,-9.6 38,-3.9 47.7,12.8c9.6,16.7 3.9,38 -12.8,47.7C61.4,320.3 40.1,314.6 30.5,297.9"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M309.1,137c-9.6,-16.7 -3.9,-38 12.8,-47.7c16.7,-9.6 38,-3.9 47.7,12.8c9.6,16.7 3.9,38 -12.8,47.7C340.1,159.4 318.7,153.7 309.1,137"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M200,395.8c-19.3,0 -34.9,-15.6 -34.9,-34.9c0,-19.3 15.6,-34.9 34.9,-34.9c19.3,0 34.9,15.6 34.9,34.9C234.9,380.1 219.3,395.8 200,395.8"
+      android:fillColor="#E535AB"/>
+  <path
+      android:pathData="M200,74c-19.3,0 -34.9,-15.6 -34.9,-34.9c0,-19.3 15.6,-34.9 34.9,-34.9c19.3,0 34.9,15.6 34.9,34.9C234.9,58.4 219.3,74 200,74"
+      android:fillColor="#E535AB"/>
+</vector>

--- a/pluto-plugins/plugins/network/core/lib/src/main/res/layout/pluto_network___item_network.xml
+++ b/pluto-plugins/plugins/network/core/lib/src/main/res/layout/pluto_network___item_network.xml
@@ -51,18 +51,17 @@
         android:id="@+id/url"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
-        android:layout_marginStart="@dimen/pluto___margin_small"
+        android:layout_marginStart="@dimen/pluto___margin_mini"
+        app:layout_goneMarginStart="@dimen/pluto___margin_small"
         android:layout_marginTop="@dimen/pluto___margin_medium"
-        android:layout_marginLeft="@dimen/pluto___margin_small"
         android:fontFamily="@font/muli_semibold"
         android:textColor="@color/pluto___text_dark"
         android:textSize="@dimen/pluto___text_small"
         android:layout_marginEnd="@dimen/pluto___margin_mini"
-        app:layout_constraintStart_toEndOf="@+id/status"
+        app:layout_constraintStart_toEndOf="@+id/graphqlIcon"
         app:layout_constraintTop_toTopOf="parent"
-        android:layout_marginRight="@dimen/pluto___margin_mini"
         app:layout_constraintEnd_toStartOf="@+id/proxyIndicator"
-        tools:text="api endpoint" />
+        tools:text="POST /api/v2" />
 
     <ImageView
         android:id="@+id/proxyIndicator"
@@ -71,17 +70,18 @@
         android:layout_marginEnd="@dimen/pluto___margin_small"
         android:layout_marginRight="@dimen/pluto___margin_small"
         android:src="@drawable/pluto_network___ic_proxy_indicator"
-        app:layout_constraintEnd_toStartOf="@id/graphqlIcon"
+        app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/url" />
 
     <ImageView
         android:id="@+id/graphqlIcon"
-        android:layout_width="12dp"
-        android:layout_height="12dp"
-        android:layout_marginEnd="@dimen/pluto___margin_small"
+        android:layout_width="@dimen/pluto___text_small"
+        android:layout_height="@dimen/pluto___text_small"
+        android:layout_marginStart="@dimen/pluto___margin_small"
         android:src="@drawable/pluto_network___ic_graphql"
-        app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toTopOf="@+id/url" />
+        app:layout_constraintBottom_toBottomOf="@id/url"
+        app:layout_constraintStart_toEndOf="@id/status"
+        app:layout_constraintTop_toTopOf="@id/url" />
 
     <TextView
         android:id="@+id/host"
@@ -90,13 +90,14 @@
         android:layout_marginTop="@dimen/pluto___margin_micro"
         android:layout_marginEnd="@dimen/pluto___margin_small"
         android:layout_marginBottom="@dimen/pluto___margin_medium"
+        android:layout_marginStart="@dimen/pluto___margin_small"
         android:ellipsize="end"
         android:fontFamily="@font/muli"
         android:textColor="@color/pluto___text_dark_60"
         android:textSize="@dimen/pluto___text_xsmall"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toStartOf="@+id/timeElapsed"
-        app:layout_constraintStart_toStartOf="@+id/url"
+        app:layout_constraintStart_toEndOf="@+id/status"
         app:layout_constraintTop_toBottomOf="@+id/url"
         android:layout_marginRight="@dimen/pluto___margin_small"
         tools:text="https host" />

--- a/pluto-plugins/plugins/network/core/lib/src/main/res/layout/pluto_network___item_network.xml
+++ b/pluto-plugins/plugins/network/core/lib/src/main/res/layout/pluto_network___item_network.xml
@@ -71,6 +71,15 @@
         android:layout_marginEnd="@dimen/pluto___margin_small"
         android:layout_marginRight="@dimen/pluto___margin_small"
         android:src="@drawable/pluto_network___ic_proxy_indicator"
+        app:layout_constraintEnd_toStartOf="@id/graphqlIcon"
+        app:layout_constraintTop_toTopOf="@+id/url" />
+
+    <ImageView
+        android:id="@+id/graphqlIcon"
+        android:layout_width="12dp"
+        android:layout_height="12dp"
+        android:layout_marginEnd="@dimen/pluto___margin_small"
+        android:src="@drawable/pluto_network___ic_graphql"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toTopOf="@+id/url" />
 

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/src/main/kotlin/com/pluto/plugins/network/ktor/PlutoKtorHelper.kt
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/src/main/kotlin/com/pluto/plugins/network/ktor/PlutoKtorHelper.kt
@@ -19,7 +19,8 @@ private val saveAttributeKey = AttributeKey<Unit>("ResponseBodySaved")
 fun HttpClient.addPlutoKtorInterceptor() {
     plugin(HttpSend).intercept { requestUnBuilt ->
         val request = requestUnBuilt.build()
-        val networkInterceptor = NetworkInterceptor.intercept(request.convert(), NetworkInterceptor.Option(NAME))
+        val convertedRequest = request.convert()
+        val networkInterceptor = NetworkInterceptor.intercept(convertedRequest, NetworkInterceptor.Option(NAME))
         val callResult = try {
             requestUnBuilt.url(networkInterceptor.actualOrMockRequestUrl)
             execute(requestUnBuilt)
@@ -34,7 +35,7 @@ fun HttpClient.addPlutoKtorInterceptor() {
             newCall.attributes.put(saveAttributeKey, Unit)
             newCall
         }
-        networkInterceptor.onResponse(res.response.convert())
+        networkInterceptor.onResponse(res.response.convert(convertedRequest))
         res
     }
 }

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/src/main/kotlin/com/pluto/plugins/network/ktor/internal/KtorResponseConverter.kt
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/src/main/kotlin/com/pluto/plugins/network/ktor/internal/KtorResponseConverter.kt
@@ -1,5 +1,6 @@
 package com.pluto.plugins.network.ktor.internal
 
+import com.pluto.plugins.network.intercept.NetworkData
 import com.pluto.plugins.network.intercept.NetworkData.Body
 import com.pluto.plugins.network.intercept.NetworkData.Response
 import io.ktor.client.statement.HttpResponse
@@ -9,15 +10,16 @@ import io.ktor.http.Headers
 import io.ktor.http.contentType
 
 internal object KtorResponseConverter : ResponseConverter<HttpResponse> {
-    override suspend fun HttpResponse.convert(): Response {
+    override suspend fun HttpResponse.convert(request: NetworkData.Request): Response {
         return Response(
+            request = request,
             statusCode = status.value,
             body = extractBody(),
             protocol = version.name,
             fromDiskCache = false,
             headers = headersMap(headers),
             sentTimestamp = requestTime.timestamp,
-            receiveTimestamp = responseTime.timestamp
+            receiveTimestamp = responseTime.timestamp,
         )
     }
 

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/src/main/kotlin/com/pluto/plugins/network/ktor/internal/ResponseConverter.kt
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/src/main/kotlin/com/pluto/plugins/network/ktor/internal/ResponseConverter.kt
@@ -1,7 +1,8 @@
 package com.pluto.plugins.network.ktor.internal
 
+import com.pluto.plugins.network.intercept.NetworkData
 import com.pluto.plugins.network.intercept.NetworkData.Response
 
 internal interface ResponseConverter<T> {
-    suspend fun T.convert(): Response
+    suspend fun T.convert(request: NetworkData.Request): Response
 }

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/src/main/kotlin/com/pluto/plugins/network/okhttp/internal/DataConvertor.kt
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/src/main/kotlin/com/pluto/plugins/network/okhttp/internal/DataConvertor.kt
@@ -36,8 +36,9 @@ internal fun Request.headerMap(contentLength: Long): Map<String, String?> {
     return map
 }
 
-internal fun Response.convert(body: NetworkData.Body?): NetworkData.Response {
+internal fun Response.convert(request: NetworkData.Request, body: NetworkData.Body?): NetworkData.Response {
     return NetworkData.Response(
+        request = request,
         statusCode = code,
         body = body,
         protocol = protocol.name,

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/src/main/kotlin/com/pluto/plugins/network/okhttp/internal/ResponseReportingSinkCallback.kt
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/src/main/kotlin/com/pluto/plugins/network/okhttp/internal/ResponseReportingSinkCallback.kt
@@ -12,6 +12,7 @@ import java.io.IOException
 
 class ResponseReportingSinkCallback(
     private val response: Response,
+    private val request: NetworkData.Request,
     private val onComplete: (NetworkData.Response) -> Unit
 ) : ReportingSink.Callback {
 
@@ -20,7 +21,7 @@ class ResponseReportingSinkCallback(
             readResponseBuffer(f, response.isGzipped)?.let {
                 val responseBody = response.body ?: return
                 val body = responseBody.processBody(it)
-                onComplete.invoke(response.convert(body))
+                onComplete.invoke(response.convert(request, body))
             }
             f.delete()
         }

--- a/sample/src/main/java/com/sampleapp/functions/network/DemoNetworkFragment.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/DemoNetworkFragment.kt
@@ -34,6 +34,10 @@ class DemoNetworkFragment : Fragment(R.layout.fragment_demo_network) {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        binding.graphqlQuery.setOnClickListener { okhttpViewModel.graphqlQuery() }
+        binding.graphqlQueryError.setOnClickListener { okhttpViewModel.graphqlQueryError() }
+        binding.graphqlMutation.setOnClickListener { okhttpViewModel.graphqlMutation() }
+        binding.graphqlMutationError.setOnClickListener { okhttpViewModel.graphqlMutationError() }
         binding.postCall.setOnClickListener { okhttpViewModel.post() }
         binding.getCall.setOnClickListener { okhttpViewModel.get() }
         binding.getCallKtor.setOnClickListener { ktorViewModel.get() }

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/custom/CustomViewModel.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/custom/CustomViewModel.kt
@@ -12,21 +12,23 @@ class CustomViewModel : ViewModel() {
     @SuppressWarnings("MagicNumber")
     fun customTrace() {
         viewModelScope.launch {
+            val request = NetworkData.Request(
+                url = "https://google.com",
+                method = "GET",
+                body = NetworkData.Body(
+                    body = "{\"message\": \"body\"}",
+                    contentType = "application/json",
+                ),
+                headers = emptyMap(),
+                sentTimestamp = System.currentTimeMillis()
+            )
             val networkInterceptor = NetworkInterceptor.intercept(
-                NetworkData.Request(
-                    url = "https://google.com",
-                    method = "GET",
-                    body = NetworkData.Body(
-                        body = "{\"message\": \"body\"}",
-                        contentType = "application/json",
-                    ),
-                    headers = emptyMap(),
-                    sentTimestamp = System.currentTimeMillis()
-                )
+                request,
             )
             delay(5_000)
             networkInterceptor.onResponse(
                 NetworkData.Response(
+                    request = request,
                     statusCode = 503,
                     body = NetworkData.Body(
                         body = "body",

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/ApiService.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/ApiService.kt
@@ -30,4 +30,7 @@ interface ApiService {
     )
     @POST("xml")
     suspend fun xml(@Body hashMapOf: RequestBody): Any
+
+    @POST("https://spacex-production.up.railway.app/")
+    suspend fun graphql(@Body body: Any): Any
 }

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/ApiService.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/ApiService.kt
@@ -31,6 +31,7 @@ interface ApiService {
     @POST("xml")
     suspend fun xml(@Body hashMapOf: RequestBody): Any
 
+    // https://studio.apollographql.com/public/SpaceX-pxxbxen/variant/current/home
     @POST("https://spacex-production.up.railway.app/")
     suspend fun graphql(@Body body: Any): Any
 }

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
@@ -25,6 +25,63 @@ class OkhttpViewModel : ViewModel() {
         }
     }
 
+    fun graphqlQuery() {
+        viewModelScope.launch {
+            // todo, better mock requests
+            enqueue {
+                apiService.graphql(
+                    mapOf(
+                        "query" to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
+                        "variables" to mapOf("limit" to 3),
+                        "operationName" to "Launches",
+                    )
+                )
+            }
+        }
+    }
+
+    fun graphqlQueryError() {
+        viewModelScope.launch {
+            enqueue {
+                apiService.graphql(
+                    mapOf(
+                        "query" to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
+                        "variables" to mapOf("limit" to -1111),
+                        "operationName" to "Launches",
+                    )
+                )
+            }
+        }
+    }
+
+    fun graphqlMutation() {
+        viewModelScope.launch {
+            enqueue {
+                apiService.graphql(
+                    mapOf(
+                        "query" to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users(objects: \$objects) {affected_rows}}",
+                        "variables" to mapOf("objects" to emptyList<Any>()),
+                        "operationName" to "Insert_users",
+                    )
+                )
+            }
+        }
+    }
+
+    fun graphqlMutationError() {
+        viewModelScope.launch {
+            enqueue {
+                apiService.graphql(
+                    mapOf(
+                        "query" to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users112231321(objects: \$objects) {affected_rows}}",
+                        "variables" to mapOf("objects" to emptyList<Any>()),
+                        "operationName" to "Insert_users",
+                    )
+                )
+            }
+        }
+    }
+
     fun post() {
         val label = "POST call"
         viewModelScope.launch {

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
@@ -30,8 +30,8 @@ class OkhttpViewModel : ViewModel() {
             enqueue {
                 apiService.graphql(
                     mapOf(
-                        "query" to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
-                        "variables" to mapOf("limit" to 3),
+                        GQL_QUERY to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
+                        GQL_VARIABLES to mapOf("limit" to GQL_LIMIT_VALID),
                     )
                 )
             }
@@ -43,8 +43,8 @@ class OkhttpViewModel : ViewModel() {
             enqueue {
                 apiService.graphql(
                     mapOf(
-                        "query" to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
-                        "variables" to mapOf("limit" to -1111),
+                        GQL_QUERY to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
+                        GQL_VARIABLES to mapOf("limit" to GQL_LIMIT_INVALID),
                     )
                 )
             }
@@ -56,8 +56,8 @@ class OkhttpViewModel : ViewModel() {
             enqueue {
                 apiService.graphql(
                     mapOf(
-                        "query" to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users(objects: \$objects) {affected_rows}}",
-                        "variables" to mapOf("objects" to emptyList<Any>()),
+                        GQL_QUERY to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users(objects: \$objects) {affected_rows}}",
+                        GQL_VARIABLES to mapOf("objects" to emptyList<Any>()),
                     )
                 )
             }
@@ -69,8 +69,8 @@ class OkhttpViewModel : ViewModel() {
             enqueue {
                 apiService.graphql(
                     mapOf(
-                        "query" to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users112231321(objects: \$objects) {affected_rows}}",
-                        "variables" to mapOf("objects" to emptyList<Any>()),
+                        GQL_QUERY to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users112231321(objects: \$objects) {affected_rows}}",
+                        GQL_VARIABLES to mapOf("objects" to emptyList<Any>()),
                     )
                 )
             }
@@ -130,5 +130,12 @@ class OkhttpViewModel : ViewModel() {
                 }
             )
         }
+    }
+
+    companion object {
+        private const val GQL_QUERY = "query"
+        private const val GQL_LIMIT_VALID = 3
+        private const val GQL_LIMIT_INVALID = -1111
+        private const val GQL_VARIABLES = "variables"
     }
 }

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
@@ -27,13 +27,12 @@ class OkhttpViewModel : ViewModel() {
 
     fun graphqlQuery() {
         viewModelScope.launch {
-            // todo, better mock requests
+            // todo, better mock responses
             enqueue {
                 apiService.graphql(
                     mapOf(
                         "query" to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
                         "variables" to mapOf("limit" to 3),
-                        "operationName" to "Launches",
                     )
                 )
             }
@@ -47,7 +46,6 @@ class OkhttpViewModel : ViewModel() {
                     mapOf(
                         "query" to "query Launches(\$limit: Int){launches(limit: \$limit){mission_name}}",
                         "variables" to mapOf("limit" to -1111),
-                        "operationName" to "Launches",
                     )
                 )
             }
@@ -61,7 +59,6 @@ class OkhttpViewModel : ViewModel() {
                     mapOf(
                         "query" to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users(objects: \$objects) {affected_rows}}",
                         "variables" to mapOf("objects" to emptyList<Any>()),
-                        "operationName" to "Insert_users",
                     )
                 )
             }
@@ -75,7 +72,6 @@ class OkhttpViewModel : ViewModel() {
                     mapOf(
                         "query" to "mutation Insert_users(\$objects: [users_insert_input!]!) {insert_users112231321(objects: \$objects) {affected_rows}}",
                         "variables" to mapOf("objects" to emptyList<Any>()),
-                        "operationName" to "Insert_users",
                     )
                 )
             }

--- a/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
+++ b/sample/src/main/java/com/sampleapp/functions/network/internal/okhttp/OkhttpViewModel.kt
@@ -27,7 +27,6 @@ class OkhttpViewModel : ViewModel() {
 
     fun graphqlQuery() {
         viewModelScope.launch {
-            // todo, better mock responses
             enqueue {
                 apiService.graphql(
                     mapOf(

--- a/sample/src/main/res/layout/fragment_container.xml
+++ b/sample/src/main/res/layout/fragment_container.xml
@@ -14,7 +14,7 @@
 
         <androidx.cardview.widget.CardView
             android:layout_width="0dp"
-            android:layout_height="440dp"
+            android:layout_height="540dp"
             android:layout_marginBottom="16dp"
             android:background="@color/appBg"
             app:cardCornerRadius="8dp"

--- a/sample/src/main/res/layout/fragment_demo_network.xml
+++ b/sample/src/main/res/layout/fragment_demo_network.xml
@@ -154,4 +154,74 @@
         app:layout_constraintTop_toBottomOf="@+id/divider1"
         app:layout_constraintVertical_bias="1" />
 
+    <TextView
+        android:id="@+id/labelGraphql"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"
+        android:background="@color/appBg"
+        android:gravity="center"
+        android:padding="4dp"
+        android:text="GraphQL"
+        android:textColor="@color/black"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/customTrace" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/graphqlQuery"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="5dp"
+        android:text="query"
+        android:textAppearance="@style/ChipTextStyle"
+        app:chipEndPadding="16dp"
+        app:chipStartPadding="16dp"
+        app:layout_constraintEnd_toStartOf="@+id/center_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/labelGraphql" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/graphqlMutation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:text="mutation"
+        android:textAppearance="@style/ChipTextStyle"
+        app:chipEndPadding="16dp"
+        app:chipStartPadding="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@+id/center_guideline"
+        app:layout_constraintTop_toBottomOf="@+id/labelGraphql" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/graphqlQueryError"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="5dp"
+        android:text="query error"
+        android:textAppearance="@style/ChipTextStyle"
+        app:chipEndPadding="16dp"
+        app:chipStartPadding="16dp"
+        app:layout_constraintEnd_toStartOf="@+id/center_guideline"
+        app:layout_constraintHorizontal_bias="1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@+id/graphqlQuery" />
+
+    <com.google.android.material.chip.Chip
+        android:id="@+id/graphqlMutationError"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="5dp"
+        android:text="mutation error"
+        android:textAppearance="@style/ChipTextStyle"
+        app:chipEndPadding="16dp"
+        app:chipStartPadding="16dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintHorizontal_bias="0"
+        app:layout_constraintStart_toEndOf="@+id/center_guideline"
+        app:layout_constraintTop_toTopOf="@+id/graphqlQueryError" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
fixes #326

Hello. I added a basic GraphQL support for network plugin. It recognises POST api calls with "query" part in it and shows query name and type instead of api path in api calls list. Also, it recognises errors in api response and paints api calls in red, even if the status code is 200.

You may not like the way it is done. I thought about making a separate graphql interceptor with apollo graphql library (https://github.com/apollographql/apollo-kotlin), but graphql calls use http under the hood, so grapqhl calls would be duplicated in http interceptor. Also different clients use different versions of apollo library (2x, 3x, 4x), and it is a bad way to add a dependency only with one version of library. I thought it would be easier to parse raw request, rather then add an interceptor, but we can discuss and I can redo the implementation.


![pluto1](https://github.com/user-attachments/assets/5bafde49-ee20-4969-b995-39a3f779ec3b) | ![pluto2](https://github.com/user-attachments/assets/2f60c8a3-cb32-4494-b997-bbf72755c21c) | ![pluto3](https://github.com/user-attachments/assets/888ea720-e6fc-4d53-a237-1f874ab39932)
-- | -- | --