### PR TITLE
fixed infinite loading problem

### DIFF
--- a/pluto-plugins/base/lib/src/main/java/com/pluto/plugin/libinterface/PlutoInterface.kt
+++ b/pluto-plugins/base/lib/src/main/java/com/pluto/plugin/libinterface/PlutoInterface.kt
@@ -27,8 +27,7 @@ class PlutoInterface private constructor(
         val libInfo: LibraryInfoInterface
             get() = LibraryInfoInterface(get.pluginActivityClass, get.selectorActivityClass)
 
-        val files: FilesInterface
-            get() = FilesInterface(get.application)
+        val files: FilesInterface by lazy { FilesInterface(get.application) } // singleton
 
         fun create(
             application: Application,

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/src/main/kotlin/com/pluto/plugins/network/okhttp/internal/ResponseReportingSinkCallback.kt
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/src/main/kotlin/com/pluto/plugins/network/okhttp/internal/ResponseReportingSinkCallback.kt
@@ -16,14 +16,10 @@ class ResponseReportingSinkCallback(
 ) : ReportingSink.Callback {
 
     override fun onSuccess(file: File?, sourceByteCount: Long) {
-        file?.let { f ->
-            readResponseBuffer(f, response.isGzipped)?.let {
-                val responseBody = response.body ?: return
-                val body = responseBody.processBody(it)
-                onComplete.invoke(response.convert(body))
-            }
-            f.delete()
-        }
+        val buffer = file?.let { readResponseBuffer(it, response.isGzipped) }
+        val body = buffer?.let { response.body.processBody(it) }
+        file?.delete()
+        onComplete.invoke(response.convert(body))
     }
 
     override fun onFailure(file: File?, exception: IOException) = exception.printStackTrace()


### PR DESCRIPTION
fixes #329
fixes #314

* Made `FilesInterface` singleton to avoid recreation of `uniqueIdGenerator` on every call.
* Rewrote `ResponseReportingSinkCallback.onSuccess` so it now always calls `onComplete.invoke()`, even if the file or buffer are invalid or empty.