### PR TITLE
chore(publish): publishing to MavenCentral implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 /scripts/publish/_newCreds.properties
 *.gpg
 /buildSrc/build
+mavenCredentials.properties

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,3 +53,4 @@ val prCheck by tasks.registering {
 
 apply (from = "$rootDir/scripts/project-dependancy-graph.gradle")
 apply (from = "$rootDir/maven-versions.gradle.kts")
+apply(from = "$rootDir/publishTasks.gradle.kts")

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,3 +14,10 @@
 android.useAndroidX=true
 kotlin.code.style=official
 org.gradle.jvmargs=-Xmx2048M -Dkotlin.daemon.jvm.options\="-Xmx2048M"
+
+# Maven Central publish credentials
+mavenCentralUsername=XXXX
+mavenCentralPassword=XXXX
+signing.keyId=XXXX
+signing.password=XXXX
+signing.secretKeyRingFile=XXXX

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,16 @@ mavenCentralPassword=XXXX
 signing.keyId=XXXX
 signing.password=XXXX
 signing.secretKeyRingFile=XXXX
+
+# Maven Central publish pom details
+pom.inceptionYear=2024
+pom.url=https://androidpluto.com
+pom.license.name=The Apache Software License, Version 2.0
+pom.license.url=http://www.apache.org/licenses/LICENSE-2.0.txt
+pom.developer.id=srtvprateek
+pom.developer.name=Prateek Srivastava
+pom.developer.email=srtv.prateek@gmail.com
+pom.scm.connection=https://github.com/androidPluto/pluto
+pom.scm.developerConnection=https://github.com/srtvprateek
+pom.scm.url=https://github.com/androidPluto/pluto
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ targetSdk = "32"
 compileSdk = "34"
 buildTools = "34.0.0"
 
-agp = "8.2.2"
+agp = "8.6.0"
 androidXCore = "1.6.0"
 androidXLifecycle = "2.8.7"
 compose = "1.7.7"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ navigation = "2.8.6"
 okhttp = "4.12.0"
 retrofit = "2.9.0"
 room = "2.5.1"
+mavenPublish = "0.28.0"
 
 [plugins]
 
@@ -35,6 +36,7 @@ kotlin-parcelize = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref =
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-plugin" }
+maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublish"}
 
 [libraries]
 

--- a/pluto-plugins/base/lib/build.gradle.kts
+++ b/pluto-plugins/base/lib/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib"
-extra["PUBLISH_ARTIFACT_ID"] = "plugin"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugin"
@@ -52,6 +51,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+extra["PUBLISH_ARTIFACT_ID"] = "plugin"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Base Plugin Module"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/base/lib/build.gradle.kts
+++ b/pluto-plugins/base/lib/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/base/lib/build.gradle.kts
+++ b/pluto-plugins/base/lib/build.gradle.kts
@@ -59,28 +59,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Base Plugin Module"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -88,19 +82,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/base/lib/build.gradle.kts
+++ b/pluto-plugins/base/lib/build.gradle.kts
@@ -53,7 +53,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto"
 extra["PUBLISH_ARTIFACT_ID"] = "plugin"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Base Plugin Module"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"

--- a/pluto-plugins/bundle/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/bundle/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "bundle-core-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Plugin Bundle"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Bundle module for Android Pluto plugins"

--- a/pluto-plugins/bundle/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/bundle/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "bundle-core-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.bundle.core"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "bundle-core-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Plugin Bundle"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Bundle module for Android Pluto plugins"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/bundle/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/bundle/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/bundle/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/bundle/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Plugin Bundle"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Bundle module for Android Pluto plugins"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/bundle/lib/build.gradle.kts
+++ b/pluto-plugins/bundle/lib/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "bundle-core"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Plugin Bundle"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Bundle module for Android Pluto plugins"

--- a/pluto-plugins/bundle/lib/build.gradle.kts
+++ b/pluto-plugins/bundle/lib/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "bundle-core"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.bundle.core"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "bundle-core"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Plugin Bundle"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Bundle module for Android Pluto plugins"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/bundle/lib/build.gradle.kts
+++ b/pluto-plugins/bundle/lib/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/bundle/lib/build.gradle.kts
+++ b/pluto-plugins/bundle/lib/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Plugin Bundle"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Bundle module for Android Pluto plugins"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Datastore Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage Datastore preferences in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
@@ -100,6 +100,5 @@ mavenPublishing {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
     implementation(libs.datastore.preferences)
 }

--- a/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "datastore-pref-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.datastore.pref"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "datastore-pref-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Datastore Preferences Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage Datastore preferences in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "datastore-pref-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Datastore Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage Datastore preferences in Android Pluto"

--- a/pluto-plugins/plugins/datastore/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib/build.gradle.kts
@@ -65,28 +65,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Datastore Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage Datastore preferences in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -94,19 +88,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/datastore/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/datastore/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib/build.gradle.kts
@@ -59,7 +59,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "datastore-pref"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Datastore Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage Datastore preferences in Android Pluto"

--- a/pluto-plugins/plugins/datastore/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/datastore/lib/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "datastore-pref"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.datastore.pref"
@@ -58,6 +57,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "datastore-pref"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Datastore Preferences Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage Datastore preferences in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Exceptions Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to capture expections & ANRs in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "exceptions-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Exceptions Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to capture expections & ANRs in Android Pluto"

--- a/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
@@ -100,5 +100,4 @@ mavenPublishing {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
 }

--- a/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "exceptions-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.exceptions"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "exceptions-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Exceptions Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to capture expections & ANRs in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
@@ -62,28 +62,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Exceptions Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to capture expections & ANRs in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -91,19 +85,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
@@ -1,18 +1,17 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "exceptions"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.exceptions"
@@ -55,6 +54,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "exceptions"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Exceptions Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to capture expections & ANRs in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/exceptions/lib/build.gradle.kts
@@ -56,7 +56,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "exceptions"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Exceptions Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to capture expections & ANRs in Android Pluto"

--- a/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "layout-inspector-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Layout inspector Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to modify screen layout in Android Pluto"

--- a/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "layout-inspector-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.layoutinspector"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "layout-inspector-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Layout inspector Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to modify screen layout in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
@@ -100,5 +100,4 @@ mavenPublishing {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
 }

--- a/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Layout inspector Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to modify screen layout in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
@@ -54,7 +54,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "layout-inspector"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Layout inspector Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to modify screen layout in Android Pluto"

--- a/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
@@ -60,28 +60,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Layout inspector Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to modify screen layout in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -89,19 +83,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/layout-inspector/lib/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "layout-inspector"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.layoutinspector"
@@ -53,6 +52,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "layout-inspector"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Layout inspector Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to modify screen layout in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
@@ -101,6 +101,5 @@ mavenPublishing {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
     api(libs.timber)
 }

--- a/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
@@ -55,28 +55,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Logger Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor logs in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -84,19 +78,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
@@ -49,7 +49,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "logger-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Logger Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor logs in Android Pluto"

--- a/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
@@ -1,16 +1,16 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "logger-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.logger"
@@ -47,6 +47,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "logger-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Logger Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor logs in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib-no-op/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
 
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/logger/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib/build.gradle.kts
@@ -62,28 +62,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Logger Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor logs in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -91,19 +85,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/logger/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib/build.gradle.kts
@@ -1,18 +1,17 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "logger"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     resourcePrefix = "pluto_logger___"
@@ -55,6 +54,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "logger"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Logger Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor logs in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/logger/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib/build.gradle.kts
@@ -56,7 +56,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "logger"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Logger Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor logs in Android Pluto"

--- a/pluto-plugins/plugins/logger/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/logger/lib/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor network calls in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "network-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor network calls in Android Pluto"

--- a/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "network-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.network"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "network-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor network calls in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/core/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib/build.gradle.kts
@@ -1,18 +1,17 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "network"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     resourcePrefix = "pluto_network___"
@@ -57,8 +56,58 @@ android {
     }
 }
 
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "network"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor network calls in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
+}
+
 dependencies {
-//    implementation 'com.plutolib:plugin:2.0.0'
     implementation(project(":pluto-plugins:base:lib"))
     implementation(libs.androidx.core)
 

--- a/pluto-plugins/plugins/network/core/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib/build.gradle.kts
@@ -56,7 +56,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "network"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor network calls in Android Pluto"

--- a/pluto-plugins/plugins/network/core/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/core/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/core/lib/build.gradle.kts
@@ -62,28 +62,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor network calls in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -91,19 +85,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-ktor-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Ktor Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor ktor network calls in Android Pluto"

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-ktor-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.network.ktor"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-ktor-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Ktor Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor ktor network calls in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Ktor Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor ktor network calls in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
@@ -62,28 +62,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Ktor Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor ktor network calls in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -91,19 +85,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
@@ -1,18 +1,17 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-ktor"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     resourcePrefix = "pluto_network___"
@@ -55,6 +54,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-ktor"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Ktor Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor ktor network calls in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-ktor/lib/build.gradle.kts
@@ -56,7 +56,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-ktor"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Ktor Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor ktor network calls in Android Pluto"

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-okhttp-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.network.okhttp"
@@ -49,7 +48,57 @@ android {
     }
 }
 
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-okhttp-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Okhttp Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor okhttp network calls in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
+}
+
 dependencies {
-//    implementation(libs.androidx.core)
     implementation(libs.okhttp)
 }

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-okhttp-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Okhttp Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor okhttp network calls in Android Pluto"

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Okhttp Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor okhttp network calls in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-okhttp"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     resourcePrefix = "pluto_network___"
@@ -55,8 +54,58 @@ android {
     }
 }
 
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-okhttp"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Okhttp Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor okhttp network calls in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
+}
+
 dependencies {
-//    implementation 'com.plutolib:plugin:2.0.0'
     implementation(project(":pluto-plugins:base:lib"))
     implementation(project(":pluto-plugins:plugins:network:core:lib"))
 

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
@@ -54,7 +54,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "network-interceptor-okhttp"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Okhttp Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor okhttp network calls in Android Pluto"

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/network/interceptor-okhttp/lib/build.gradle.kts
@@ -60,28 +60,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Network Okhttp Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to monitor okhttp network calls in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -89,19 +83,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Rooms DB Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage & alter Rooms database in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
@@ -100,5 +100,4 @@ mavenPublishing {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
 }

--- a/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "rooms-db-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.rooms.db"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "rooms-db-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Rooms DB Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage & alter Rooms database in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "rooms-db-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Rooms DB Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage & alter Rooms database in Android Pluto"

--- a/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
@@ -62,28 +62,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Rooms DB Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage & alter Rooms database in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -91,19 +85,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
@@ -1,18 +1,17 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kotlin.parcelize)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "rooms-db"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     resourcePrefix = "pluto_rooms___"
@@ -55,6 +54,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "rooms-db"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Rooms DB Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage & alter Rooms database in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/rooms-database/lib/build.gradle.kts
@@ -56,7 +56,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "rooms-db"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Rooms DB Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manage & alter Rooms database in Android Pluto"

--- a/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
@@ -48,7 +48,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "preferences-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Shared Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manager Shared Preferences in Android Pluto"

--- a/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
@@ -100,5 +100,4 @@ mavenPublishing {
 }
 
 dependencies {
-    implementation(libs.androidx.core)
 }

--- a/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
@@ -54,28 +54,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Shared Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manager Shared Preferences in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -83,19 +77,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "preferences-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto.plugins.preferences"
@@ -47,6 +46,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "preferences-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Shared Preferences Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manager Shared Preferences in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
@@ -1,17 +1,16 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
-extra["PUBLISH_ARTIFACT_ID"] = "preferences"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     resourcePrefix = "pluto_pref___"
@@ -56,8 +55,58 @@ android {
     }
 }
 
+extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_ARTIFACT_ID"] = "preferences"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Shared Preferences Plugin"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manager Shared Preferences in Android Pluto"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
+}
+
 dependencies {
-//    implementation 'com.plutolib:plugin:2.0.0'
     implementation(project(":pluto-plugins:base:lib"))
     implementation(libs.androidx.core)
     implementation(libs.androidx.navigation.ui)

--- a/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
@@ -55,7 +55,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib.plugins"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto.plugins"
 extra["PUBLISH_ARTIFACT_ID"] = "preferences"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Shared Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manager Shared Preferences in Android Pluto"

--- a/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
+++ b/pluto-plugins/plugins/shared-preferences/lib/build.gradle.kts
@@ -61,28 +61,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto Shared Preferences Plugin"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Plugin to manager Shared Preferences in Android Pluto"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -90,19 +84,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto/lib-no-op/build.gradle.kts
+++ b/pluto/lib-no-op/build.gradle.kts
@@ -58,28 +58,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -87,19 +81,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto/lib-no-op/build.gradle.kts
+++ b/pluto/lib-no-op/build.gradle.kts
@@ -52,7 +52,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto"
 extra["PUBLISH_ARTIFACT_ID"] = "pluto-no-op"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"

--- a/pluto/lib-no-op/build.gradle.kts
+++ b/pluto/lib-no-op/build.gradle.kts
@@ -3,7 +3,7 @@ import com.vanniktech.maven.publish.SonatypeHost
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto/lib-no-op/build.gradle.kts
+++ b/pluto/lib-no-op/build.gradle.kts
@@ -1,16 +1,15 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
 val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
-
-extra["PUBLISH_GROUP_ID"] = "com.plutolib"
-extra["PUBLISH_ARTIFACT_ID"] = "pluto-no-op"
-extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto"
@@ -51,6 +50,57 @@ android {
         abortOnError = false
         targetSdk = libs.versions.targetSdk.get().toInt()
     }
+}
+
+extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+extra["PUBLISH_ARTIFACT_ID"] = "pluto-no-op"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"
+
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
+
+        licenses {
+            license {
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
 }
 
 dependencies {

--- a/pluto/lib/build.gradle.kts
+++ b/pluto/lib/build.gradle.kts
@@ -60,28 +60,22 @@ extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"
 
 mavenPublishing {
-    // Define coordinates for the published artifact
     coordinates(
         groupId = extra["PUBLISH_GROUP_ID"] as String,
         artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
         version = verPublish
     )
-
-    // Configure POM metadata for the published artifact
     pom {
         name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
         description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
         inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
         url.set(project.findProperty("pom.url") as? String)
-
         licenses {
             license {
                 name.set(project.findProperty("pom.license.name") as? String)
                 url.set(project.findProperty("pom.license.url") as? String)
             }
         }
-
-        // Specify developers information
         developers {
             developer {
                 id.set(project.findProperty("pom.developer.id") as? String)
@@ -89,19 +83,13 @@ mavenPublishing {
                 email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
-
-        // Specify SCM information
         scm {
             connection.set(project.findProperty("pom.scm.connection") as? String)
             developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
             url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
-
-    // Configure publishing to Maven Central
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
-
-    // Enable GPG signing for all publications
     signAllPublications()
 }
 

--- a/pluto/lib/build.gradle.kts
+++ b/pluto/lib/build.gradle.kts
@@ -12,10 +12,6 @@ val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
 
-// extra["PUBLISH_GROUP_ID"] = "com.plutolib"
-// extra["PUBLISH_ARTIFACT_ID"] = "pluto"
-// extra["PUBLISH_VERSION"] = verPublish
-
 android {
     namespace = "com.pluto"
     resourcePrefix = "pluto___"
@@ -58,40 +54,47 @@ android {
     }
 }
 
+extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+extra["PUBLISH_ARTIFACT_ID"] = "pluto"
+extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto"
+extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"
+
 mavenPublishing {
     // Define coordinates for the published artifact
     coordinates(
-        groupId = "com.plutolib",
-        artifactId = "pluto",
-        version = "1.0.2"
+        groupId = extra["PUBLISH_GROUP_ID"] as String,
+        artifactId = extra["PUBLISH_ARTIFACT_ID"] as String,
+        version = verPublish
     )
 
     // Configure POM metadata for the published artifact
     pom {
-        name.set("Math KMP Library")
-        description.set("Sample Kotlin MultiPlatform Library Test")
-        inceptionYear.set("2024")
-        url.set("https://github.com/<GITHUB_USER_NAME>/MathLibGuide")
+        name.set(extra["PUBLISH_ARTIFACT_NAME"] as String)
+        description.set(extra["PUBLISH_ARTIFACT_DESCRIPTION"] as String)
+        inceptionYear.set(project.findProperty("pom.inceptionYear") as? String)
+        url.set(project.findProperty("pom.url") as? String)
 
         licenses {
             license {
-                name.set("MIT")
-                url.set("https://opensource.org/licenses/MIT")
+                name.set(project.findProperty("pom.license.name") as? String)
+                url.set(project.findProperty("pom.license.url") as? String)
             }
         }
 
         // Specify developers information
         developers {
             developer {
-                id.set("<GITHUB_USER_NAME>")
-                name.set("<GITHUB_ACTUAL_NAME>")
-                email.set("<GITHUB_EMAIL_ADDRESS>")
+                id.set(project.findProperty("pom.developer.id") as? String)
+                name.set(project.findProperty("pom.developer.name") as? String)
+                email.set(project.findProperty("pom.developer.email") as? String)
             }
         }
 
         // Specify SCM information
         scm {
-            url.set("https://github.com/<GITHUB_USER_NAME>/MathLibGuide")
+            connection.set(project.findProperty("pom.scm.connection") as? String)
+            developerConnection.set(project.findProperty("pom.scm.developerConnection") as? String)
+            url.set(project.findProperty("pom.scm.url") as? String)
         }
     }
 
@@ -116,6 +119,4 @@ dependencies {
 
     implementation(libs.moshi)
     ksp(libs.moshi.codegen)
-
-    implementation("com.vanniktech:gradle-maven-publish-plugin:0.28.0")
 }

--- a/pluto/lib/build.gradle.kts
+++ b/pluto/lib/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
-    id("com.vanniktech.maven.publish") version "0.28.0"
+    alias(libs.plugins.maven.publish)
 }
 
 val version = Versioning.loadVersioningData()

--- a/pluto/lib/build.gradle.kts
+++ b/pluto/lib/build.gradle.kts
@@ -54,7 +54,7 @@ android {
     }
 }
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+extra["PUBLISH_GROUP_ID"] = "com.androidpluto"
 extra["PUBLISH_ARTIFACT_ID"] = "pluto"
 extra["PUBLISH_ARTIFACT_NAME"] = "Android Pluto"
 extra["PUBLISH_ARTIFACT_DESCRIPTION"] = "Open Sourced, on-device debugger for Android apps"

--- a/pluto/lib/build.gradle.kts
+++ b/pluto/lib/build.gradle.kts
@@ -1,7 +1,10 @@
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
+    id("com.vanniktech.maven.publish") version "0.28.0"
 }
 
 val version = Versioning.loadVersioningData()
@@ -9,9 +12,9 @@ val verCode = version["code"] as Int
 val verPublish = version["publish"] as String
 val verGitSHA = version["gitSha"] as String
 
-extra["PUBLISH_GROUP_ID"] = "com.plutolib"
-extra["PUBLISH_ARTIFACT_ID"] = "pluto"
-extra["PUBLISH_VERSION"] = verPublish
+// extra["PUBLISH_GROUP_ID"] = "com.plutolib"
+// extra["PUBLISH_ARTIFACT_ID"] = "pluto"
+// extra["PUBLISH_VERSION"] = verPublish
 
 android {
     namespace = "com.pluto"
@@ -55,6 +58,50 @@ android {
     }
 }
 
+mavenPublishing {
+    // Define coordinates for the published artifact
+    coordinates(
+        groupId = "com.plutolib",
+        artifactId = "pluto",
+        version = "1.0.2"
+    )
+
+    // Configure POM metadata for the published artifact
+    pom {
+        name.set("Math KMP Library")
+        description.set("Sample Kotlin MultiPlatform Library Test")
+        inceptionYear.set("2024")
+        url.set("https://github.com/<GITHUB_USER_NAME>/MathLibGuide")
+
+        licenses {
+            license {
+                name.set("MIT")
+                url.set("https://opensource.org/licenses/MIT")
+            }
+        }
+
+        // Specify developers information
+        developers {
+            developer {
+                id.set("<GITHUB_USER_NAME>")
+                name.set("<GITHUB_ACTUAL_NAME>")
+                email.set("<GITHUB_EMAIL_ADDRESS>")
+            }
+        }
+
+        // Specify SCM information
+        scm {
+            url.set("https://github.com/<GITHUB_USER_NAME>/MathLibGuide")
+        }
+    }
+
+    // Configure publishing to Maven Central
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
+
+    // Enable GPG signing for all publications
+    signAllPublications()
+}
+
 dependencies {
     api(project(":pluto-plugins:base:lib"))
 
@@ -69,4 +116,6 @@ dependencies {
 
     implementation(libs.moshi)
     ksp(libs.moshi.codegen)
+
+    implementation("com.vanniktech:gradle-maven-publish-plugin:0.28.0")
 }

--- a/pluto/lib/src/main/java/com/pluto/maven/MavenApiService.kt
+++ b/pluto/lib/src/main/java/com/pluto/maven/MavenApiService.kt
@@ -4,6 +4,6 @@ import retrofit2.http.GET
 
 internal interface MavenApiService {
 
-    @GET("https://search.maven.org/solrsearch/select?q=g:com.plutolib+AND+a:pluto")
+    @GET("https://search.maven.org/solrsearch/select?q=g:com.androidpluto+AND+a:pluto")
     suspend fun getLatestVersion(): MavenData
 }

--- a/publishTasks.gradle.kts
+++ b/publishTasks.gradle.kts
@@ -1,0 +1,43 @@
+import java.util.Properties
+
+tasks.register("publishAndReleaseWithMavenCredentials") {
+    doLast {
+        val gradleFile = file("$rootDir/gradle.properties")
+        val credentialsFile = file("$rootDir/mavenCredentials.properties")
+
+        if (!credentialsFile.exists()) {
+            throw GradleException("❌ Credential file not found: $credentialsFile")
+        }
+
+        // Read existing gradle.properties content into a mutable map
+        val gradleProperties = Properties().apply { load(gradleFile.inputStream()) }.toMutableMap()
+
+        // Read credentials from credential.properties
+        val credentials = Properties().apply { load(credentialsFile.inputStream()) }
+
+        // Backup original gradle.properties content
+        val originalContent = gradleFile.readText()
+
+        // Override common keys & keep non-overlapping keys untouched
+        credentials.forEach { (key, value) -> gradleProperties[key.toString()] = value.toString() }
+        gradleProperties["signing.secretKeyRingFile"] = "$rootDir/secring.gpg"
+
+        // Write updated gradle.properties back to file
+        gradleFile.writer().use { writer ->
+            gradleProperties.forEach { (key, value) -> writer.write("$key=$value\n") }
+        }
+
+        try {
+            // Run the Gradle publish command
+            println("🔹 Running Gradle publish task with temporary credentials...")
+            exec {
+                commandLine("./gradlew", "publishToMavenCentral", "--no-configuration-cache")
+//                commandLine("./gradlew", "publishAndReleaseToMavenCentral", "--no-configuration-cache")
+            }
+        } finally {
+            // Revert gradle.properties to original state
+            println("🔄 Reverting gradle.properties...")
+            gradleFile.writeText(originalContent)
+        }
+    }
+}

--- a/publishTasks.gradle.kts
+++ b/publishTasks.gradle.kts
@@ -1,6 +1,15 @@
 import java.util.Properties
 
-tasks.register("publishAndReleaseWithMavenCredentials") {
+/**
+ * Usage
+ * ./gradlew publishOnMavenCentral -PshouldRelease=false
+ *
+ * shouldRelease=true will publish & release the build. no manual intervention needed
+ * shouldRelease=false will only publish the build, need to manually release from https://central.sonatype.com/publishing/deployments
+ */
+tasks.register("publishOnMavenCentral") {
+    val shouldRelease = project.findProperty("shouldRelease")?.toString()?.toBoolean() ?: false
+
     doLast {
         val gradleFile = file("$rootDir/gradle.properties")
         val credentialsFile = file("$rootDir/mavenCredentials.properties")
@@ -28,12 +37,16 @@ tasks.register("publishAndReleaseWithMavenCredentials") {
         }
 
         try {
+            val releaseCommand =
+                if (shouldRelease) "publishAndReleaseToMavenCentral" else "publishToMavenCentral"
+            val releaseCommandMessage = if (shouldRelease) "Publish & Release" else "Publish"
             // Run the Gradle publish command
-            println("🔹 Running Gradle publish task with temporary credentials...")
-            exec {
-                commandLine("./gradlew", "publishToMavenCentral", "--no-configuration-cache")
-//                commandLine("./gradlew", "publishAndReleaseToMavenCentral", "--no-configuration-cache")
+            println("🔹 Running Gradle publish task : $releaseCommandMessage")
+            project.exec {
+                commandLine("./gradlew", releaseCommand, "--no-configuration-cache")
             }
+            println("✅ $releaseCommandMessage successful!")
+            println("Validate the deployment at https://central.sonatype.com/publishing/deployments")
         } finally {
             // Revert gradle.properties to original state
             println("🔄 Reverting gradle.properties...")

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -83,19 +83,19 @@ dependencies {
     "debugImplementation"(project(":pluto-plugins:bundle:lib"))
 
     /* Maven Op dependencies */
-    "debugMavenImplementation"("com.plutolib:pluto:$verPublish")
-    "debugMavenImplementation"("com.plutolib.plugins:bundle-core:$verPublish")
+    "debugMavenImplementation"("com.androidpluto:pluto:$verPublish")
+    "debugMavenImplementation"("com.androidpluto.plugins:bundle-core:$verPublish")
 
     /* Local NoOp dependencies */
     "debugNoOpImplementation"(project(":pluto:lib-no-op"))
     "debugNoOpImplementation"(project(":pluto-plugins:bundle:lib-no-op"))
 
     /* Maven NoOp dependencies */
-    "debugNoOpMavenImplementation"("com.plutolib:pluto-no-op:$verPublish")
-    "debugNoOpMavenImplementation"("com.plutolib.plugins:bundle-core-no-op:$verPublish")
+    "debugNoOpMavenImplementation"("com.androidpluto:pluto-no-op:$verPublish")
+    "debugNoOpMavenImplementation"("com.androidpluto.plugins:bundle-core-no-op:$verPublish")
 
-    "releaseImplementation"("com.plutolib:pluto:$verPublish")
-    "releaseImplementation"("com.plutolib.plugins:bundle-core:$verPublish")
+    "releaseImplementation"("com.androidpluto:pluto:$verPublish")
+    "releaseImplementation"("com.androidpluto.plugins:bundle-core:$verPublish")
 
     /**
      * Other dependencies


### PR DESCRIPTION
Due to [deprecation of issues.sonatype.org](https://central.sonatype.org/faq/what-happened-to-issues-sonatype-org/), our publish scripts started breaking.
This PR will be resolving the issue by migrating the publish scripts to central.sonatype.com