### PR TITLE
feat: support HTTP URLs in Network Mock Settings

### DIFF
--- a/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/mock/ui/MockSettingsViewModel.kt
+++ b/pluto-plugins/plugins/network/lib/src/main/java/com/pluto/plugins/network/internal/mock/ui/MockSettingsViewModel.kt
@@ -40,8 +40,8 @@ internal class MockSettingsViewModel(application: Application) : AndroidViewMode
     }
 
     fun update(requestUrl: String, requestMethod: String, mockData: MockData) {
-        if (!URLUtil.isHttpsUrl(mockData.url)) {
-            _event.postValue(Pair(false, "Need https:// URL"))
+        if (!URLUtil.isHttpUrl(mockData.url) && !URLUtil.isHttpsUrl(mockData.url)) {
+            _event.postValue(Pair(false, "URL must start with http:// or https://"))
             return
         }
         if (mockData.url.length < URL_MIN_LENGTH) { // length of https://


### PR DESCRIPTION
## Description
This Pull Request introduces support for `http://` URLs in the Network Mocking feature. Previously, the validation logic was restricted to `https://` URLs only, which limited developers when testing against local development servers or non-secure staging environments.

## Changes
- Updated `MockSettingsViewModel.kt` validation logic to permit both `http` and `https` protocols using `URLUtil`.
- Updated the UI error message to inform users that both `http://` and `https://` prefixes are now valid.

## Technical Note: Cleartext Traffic (Debugging Only)
If you encounter a `Cleartext HTTP traffic not permitted` error while using `http` URLs (standard behavior on Android 9+), you can temporarily allow it by adding the following attribute to your `AndroidManifest.xml`:

```xml
<application
    android:usesCleartextTraffic="true"
    ...>
</application>
```

**IMPORTANT**
> **Security Warning:** The `usesCleartextTraffic` attribute should **ONLY** be used for debugging and local testing. Do not enable this in production as it allows unencrypted network traffic, which poses a significant security risk.

## Checklist
- [x] Supports `http://` URLs
- [x] Supports `https://` URLs
- [x] Updated validation error messages
