### PR TITLE
feat: implement edge-to-edge support across Pluto

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ compileSdk = "34"
 buildTools = "34.0.0"
 
 agp = "8.6.0"
+androidXActivity = "1.9.0"
 androidXCore = "1.6.0"
 androidXLifecycle = "2.8.7"
 detekt = "1.19.0"
@@ -42,6 +43,7 @@ maven-publish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPubli
 
 [libraries]
 
+androidx-activity = { module = "androidx.activity:activity-ktx", version.ref = "androidXActivity" }
 androidx-annotation = { module = "androidx.annotation:annotation", version = "1.4.0" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version = "1.4.0" }
 androidx-browser = { module = "androidx.browser:browser", version = "1.4.0" }

--- a/pluto-plugins/base/lib/src/main/res/layout/pluto___selector_dialog.xml
+++ b/pluto-plugins/base/lib/src/main/res/layout/pluto___selector_dialog.xml
@@ -20,7 +20,6 @@
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/pluto-plugins/plugins/datastore/lib/src/main/res/layout/pluto_dts___fragment_base.xml
+++ b/pluto-plugins/plugins/datastore/lib/src/main/res/layout/pluto_dts___fragment_base.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/pluto___white"
-    android:fitsSystemWindows="true">
+    android:background="@color/pluto___white">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"

--- a/pluto-plugins/plugins/exceptions/lib/src/main/res/layout/pluto_excep___fragment_base.xml
+++ b/pluto-plugins/plugins/exceptions/lib/src/main/res/layout/pluto_excep___fragment_base.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/pluto___white"
-    android:fitsSystemWindows="true">
+    android:background="@color/pluto___white">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/ViewInfoFragment.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/ViewInfoFragment.kt
@@ -4,8 +4,6 @@ import android.os.Bundle
 import android.view.View
 import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.core.os.bundleOf
-import androidx.core.view.ViewCompat
-import androidx.core.view.WindowInsetsCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.lifecycle.Observer
@@ -31,11 +29,6 @@ internal class ViewInfoFragment : Fragment(R.layout.pluto_li___fragment_view_inf
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, insets ->
-            val systemBarsInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars())
-            binding.bsContainer.previewPanelBottomSheet.setPadding(0, 0, 0, systemBarsInsets.bottom)
-            insets
-        }
         ActivityLifecycle.topActivity?.let { binding.operableView.tryGetFrontView(it) }
         binding.operableView.setOnClickListener(this)
         binding.leftControls.initialise(

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/hierarchy/ViewHierarchyFragment.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/hierarchy/ViewHierarchyFragment.kt
@@ -4,7 +4,11 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -49,8 +53,21 @@ internal class ViewHierarchyFragment : DialogFragment() {
 
     override fun getTheme(): Int = R.style.PlutoLIFullScreenDialogStyle
 
+    override fun onStart() {
+        super.onStart()
+        dialog?.window?.let { WindowCompat.setDecorFitsSystemWindows(it, false) }
+    }
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        val appBarContentInitialPaddingTop = binding.appBarContent.paddingTop
+        val listInitialPaddingBottom = binding.list.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.appBarContent.updatePadding(top = appBarContentInitialPaddingTop + insets.top)
+            binding.list.updatePadding(bottom = listInitialPaddingBottom + insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
         onBackPressed { findNavController().navigateUp() }
         binding.close.setOnDebounceClickListener {
             findNavController().navigateUp()

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/inspect/InspectOverlay.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/inspect/InspectOverlay.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import androidx.core.view.children
+import androidx.core.view.doOnLayout
 import com.pluto.plugins.layoutinspector.internal.inspect.canvas.CaptureCanvas
 import com.pluto.plugins.layoutinspector.internal.inspect.canvas.DimensionCanvas
 import com.pluto.plugins.layoutinspector.internal.inspect.canvas.GridCanvas
@@ -62,7 +63,15 @@ internal class InspectOverlay : View {
     }
 
     fun tryGetFrontView(targetActivity: Activity) {
-        traverse(targetActivity.getFrontView())
+        // Defer the view traversal until after this overlay has completed its own layout
+        // pass so that getLocationOnScreen() (called inside InspectedView.reset()) returns
+        // the correct screen position, not [0, 0].  doOnLayout fires synchronously when the
+        // view is already laid out, or on the next layout pass otherwise – covering both the
+        // "first launch" and "navigate-back" cases.
+        doOnLayout {
+            traverse(targetActivity.getFrontView())
+            invalidate()
+        }
     }
 
     override fun onTouchEvent(event: MotionEvent?): Boolean {
@@ -241,7 +250,9 @@ internal class InspectOverlay : View {
 
     private fun traverse(view: View) {
         if (view.alpha == 0f || view.visibility != VISIBLE) return
-        inspectedViews.add(InspectedView(view))
+        // Pass 'this' so InspectedView can dynamically compute the overlay's screen offset
+        // inside each reset() call, keeping all rects in overlay-local coordinates.
+        inspectedViews.add(InspectedView(view, this))
         if (view is ViewGroup) {
             view.children.forEach {
                 traverse(it)

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/inspect/InspectedView.kt
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/java/com/pluto/plugins/layoutinspector/internal/inspect/InspectedView.kt
@@ -3,16 +3,28 @@ package com.pluto.plugins.layoutinspector.internal.inspect
 import android.graphics.Rect
 import android.view.View
 
-internal class InspectedView(val view: View) {
+/**
+ * Wraps an inspected [view] and maintains a [rect] in **overlay-local coordinates**
+ * (i.e. relative to the top-left of [InspectOverlay]) so that hit-testing and canvas
+ * drawing are both correct regardless of whether the host (Pluto) activity is running
+ * edge-to-edge or not.
+ *
+ * @param overlay The [InspectOverlay] view. Its current screen position is subtracted
+ *   from [view]'s screen position inside every [reset] call, so the stored [rect] is
+ *   always in overlay-local space even after window-inset changes.
+ */
+internal class InspectedView(val view: View, private val overlay: View? = null) {
 
     private val originRect: Rect = Rect()
     val rect: Rect = Rect()
     private val location = IntArray(2)
+    private val overlayLoc = IntArray(2)
+
     val parent: InspectedView?
         get() {
             val parentView: Any = view.parent
             return if (parentView is View) {
-                InspectedView(parentView)
+                InspectedView(parentView, overlay)
             } else {
                 null
             }
@@ -24,10 +36,16 @@ internal class InspectedView(val view: View) {
     }
 
     fun reset() {
+        // Always recompute the overlay's position so this works correctly even if called
+        // before the first layout pass (overlayLoc will just be [0,0] then, harmlessly).
+        overlay?.getLocationOnScreen(overlayLoc)
         view.getLocationOnScreen(location)
-        val left = location[0]
+        // Subtract the overlay's screen offset → rect is in overlay-local space.
+        // This cancels out the status-bar (and/or action-bar) offset introduced by the
+        // Pluto activity's paddingTop when edge-to-edge is enabled.
+        val left = location[0] - overlayLoc[0]
         val right = left + view.width
-        val top = location[1]
+        val top = location[1] - overlayLoc[1]
         val bottom = top + view.height
         rect.set(left, top, right, bottom)
     }

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/res/layout/pluto_li___fragment_view_attr.xml
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/res/layout/pluto_li___fragment_view_attr.xml
@@ -21,7 +21,6 @@
         <androidx.constraintlayout.widget.ConstraintLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/res/layout/pluto_li___fragment_view_hierarchy.xml
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/res/layout/pluto_li___fragment_view_hierarchy.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:fitsSystemWindows="true"
     android:background="@color/pluto___white">
 
     <com.google.android.material.appbar.AppBarLayout
@@ -13,6 +12,7 @@
         android:theme="@style/PlutoTheme.AppBarOverlay">
 
         <androidx.constraintlayout.widget.ConstraintLayout
+            android:id="@+id/appBarContent"
             android:layout_width="match_parent"
             android:layout_height="wrap_content">
 

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/res/layout/pluto_li___fragment_view_info.xml
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/res/layout/pluto_li___fragment_view_info.xml
@@ -15,8 +15,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:fitsSystemWindows="true">
+        android:layout_height="wrap_content">
 
         <com.pluto.plugins.layoutinspector.internal.control.ControlsWidget
             android:id="@+id/leftControls"

--- a/pluto-plugins/plugins/layout-inspector/lib/src/main/res/values/styles.xml
+++ b/pluto-plugins/plugins/layout-inspector/lib/src/main/res/values/styles.xml
@@ -28,5 +28,7 @@
         <item name="android:windowFullscreen">false</item>
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:windowIsFloating">false</item>
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
     </style>
 </resources>

--- a/pluto-plugins/plugins/logger/lib/src/main/res/layout/pluto_logger___fragment_logs.xml
+++ b/pluto-plugins/plugins/logger/lib/src/main/res/layout/pluto_logger___fragment_logs.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/pluto___white"
-    android:fitsSystemWindows="true">
+    android:background="@color/pluto___white">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"

--- a/pluto-plugins/plugins/network/lib/src/main/res/layout/pluto_network___fragment_network.xml
+++ b/pluto-plugins/plugins/network/lib/src/main/res/layout/pluto_network___fragment_network.xml
@@ -5,7 +5,6 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:background="@color/pluto___white"
-    android:fitsSystemWindows="true"
     tools:context=".base.internal.NetworkFragment">
 
     <androidx.fragment.app.FragmentContainerView

--- a/pluto-plugins/plugins/rooms-database/lib/src/main/res/layout/pluto_rooms___fragment_data_editor.xml
+++ b/pluto-plugins/plugins/rooms-database/lib/src/main/res/layout/pluto_rooms___fragment_data_editor.xml
@@ -19,7 +19,6 @@
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/pluto-plugins/plugins/rooms-database/lib/src/main/res/layout/pluto_rooms___fragment_filter.xml
+++ b/pluto-plugins/plugins/rooms-database/lib/src/main/res/layout/pluto_rooms___fragment_filter.xml
@@ -19,7 +19,6 @@
         <androidx.coordinatorlayout.widget.CoordinatorLayout
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:fitsSystemWindows="true"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintTop_toTopOf="parent">
 

--- a/pluto-plugins/plugins/rooms-database/lib/src/main/res/layout/pluto_rooms___fragment_rooms_db.xml
+++ b/pluto-plugins/plugins/rooms-database/lib/src/main/res/layout/pluto_rooms___fragment_rooms_db.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/pluto___white"
-    android:fitsSystemWindows="true">
+    android:background="@color/pluto___white">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"

--- a/pluto-plugins/plugins/shared-preferences/lib/src/main/res/layout/pluto_pref___fragment_base.xml
+++ b/pluto-plugins/plugins/shared-preferences/lib/src/main/res/layout/pluto_pref___fragment_base.xml
@@ -3,8 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:background="@color/pluto___white"
-    android:fitsSystemWindows="true">
+    android:background="@color/pluto___white">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/container"

--- a/pluto/lib/build.gradle.kts
+++ b/pluto/lib/build.gradle.kts
@@ -96,6 +96,7 @@ mavenPublishing {
 dependencies {
     api(project(":pluto-plugins:base:lib"))
 
+    implementation(libs.androidx.activity)
     implementation(libs.androidx.core)
     implementation(libs.androidx.appcompat)
 

--- a/pluto/lib/src/main/java/com/pluto/tool/modules/ruler/RulerActivity.kt
+++ b/pluto/lib/src/main/java/com/pluto/tool/modules/ruler/RulerActivity.kt
@@ -3,7 +3,11 @@ package com.pluto.tool.modules.ruler
 import android.os.Bundle
 import android.view.View.GONE
 import android.view.View.VISIBLE
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import com.pluto.R
 import com.pluto.databinding.PlutoToolRulerActivityBinding
 import com.pluto.tool.modules.ruler.internal.ControlsWidget
@@ -28,8 +32,21 @@ class RulerActivity : AppCompatActivity() {
      */
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = PlutoToolRulerActivityBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        val controlsInitialTopMargin =
+            (binding.leftControls.layoutParams as? ConstraintLayout.LayoutParams)?.topMargin ?: 0
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { _, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            listOf(binding.leftControls, binding.rightControls).forEach { controls ->
+                (controls.layoutParams as? ConstraintLayout.LayoutParams)?.let { params ->
+                    params.topMargin = controlsInitialTopMargin + insets.top
+                    controls.layoutParams = params
+                }
+            }
+            WindowInsetsCompat.CONSUMED
+        }
 
         // Add the ruler fragment to the container
         supportFragmentManager.beginTransaction().apply {

--- a/pluto/lib/src/main/java/com/pluto/ui/container/PlutoActivity.kt
+++ b/pluto/lib/src/main/java/com/pluto/ui/container/PlutoActivity.kt
@@ -2,10 +2,11 @@ package com.pluto.ui.container
 
 import android.content.Intent
 import android.os.Bundle
-import android.view.WindowManager
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import androidx.core.content.ContextCompat
-import androidx.core.view.WindowCompat
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.lifecycle.Observer
 import com.pluto.Pluto
 import com.pluto.R
@@ -33,15 +34,14 @@ class PlutoActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         val binding = PlutoActivityPlutoBinding.inflate(layoutInflater)
         setContentView(binding.root)
-        WindowCompat.setDecorFitsSystemWindows(window, false)
-        window.setFlags(
-            WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION,
-            WindowManager.LayoutParams.FLAG_TRANSLUCENT_NAVIGATION
-        )
-        window.addFlags(WindowManager.LayoutParams.FLAG_DRAWS_SYSTEM_BAR_BACKGROUNDS)
-        window.statusBarColor = ContextCompat.getColor(this, com.pluto.plugin.R.color.pluto___dark)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(top = insets.top, bottom = insets.bottom)
+            windowInsets
+        }
         sharer.data.observe(this) {
             val shareFragment = ShareFragment()
             shareFragment.arguments = Bundle().apply {
@@ -110,7 +110,7 @@ class PlutoActivity : AppCompatActivity() {
 //        }
 //    }
 
-    override fun onNewIntent(intent: Intent?) {
+    override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
         handleIntent(intent)
     }

--- a/pluto/lib/src/main/java/com/pluto/ui/selector/SelectorActivity.kt
+++ b/pluto/lib/src/main/java/com/pluto/ui/selector/SelectorActivity.kt
@@ -8,9 +8,9 @@ import android.view.View.GONE
 import android.view.View.VISIBLE
 import android.view.animation.Animation
 import android.view.animation.AnimationUtils
+import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
 import androidx.annotation.AnimRes
-import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
@@ -105,6 +105,10 @@ class SelectorActivity : FragmentActivity() {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(MavenSession.releaseUrl)))
         }
 
+        setupObservers()
+    }
+
+    private fun setupObservers() {
         Pluto.appStateCallback.state.removeObserver(appStateListener)
         Pluto.appStateCallback.state.observe(this, appStateListener)
 

--- a/pluto/lib/src/main/java/com/pluto/ui/selector/SelectorActivity.kt
+++ b/pluto/lib/src/main/java/com/pluto/ui/selector/SelectorActivity.kt
@@ -10,7 +10,11 @@ import android.view.animation.Animation
 import android.view.animation.AnimationUtils
 import androidx.activity.viewModels
 import androidx.annotation.AnimRes
+import androidx.activity.enableEdgeToEdge
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.isVisible
+import androidx.core.view.updatePadding
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Observer
 import androidx.recyclerview.widget.GridLayoutManager
@@ -54,9 +58,20 @@ class SelectorActivity : FragmentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         binding = PlutoActivityPluginSelectorBinding.inflate(layoutInflater)
         setContentView(binding.root)
         overridePendingTransition(R.anim.pluto___slide_in_bottom, R.anim.pluto___slide_out_bottom)
+        val rootInitialPaddingTop = binding.root.paddingTop
+        val rootInitialPaddingBottom = binding.root.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            v.updatePadding(
+                top = rootInitialPaddingTop + insets.top,
+                bottom = rootInitialPaddingBottom + insets.bottom
+            )
+            WindowInsetsCompat.CONSUMED
+        }
         selectorUtils = SelectorUtils(this)
 
         binding.list.apply {

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -101,6 +101,7 @@ dependencies {
      * Other dependencies
      */
     implementation(libs.kotlin.stdlib.jdk8)
+    implementation(libs.androidx.activity)
     implementation(libs.androidx.appcompat)
     implementation(libs.androidx.core)
     implementation(libs.androidx.constraintlayout)

--- a/sample/src/main/java/com/sampleapp/MainActivity.kt
+++ b/sample/src/main/java/com/sampleapp/MainActivity.kt
@@ -2,7 +2,11 @@ package com.sampleapp
 
 import android.content.Intent
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import com.google.android.material.chip.Chip
 import com.pluto.Pluto
 import com.pluto.plugins.layoutinspector.PlutoLayoutInspectorPlugin
@@ -15,8 +19,16 @@ class MainActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         val binding = ActivityMainBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        val actionsViewInitialPaddingBottom = binding.actionsView.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.appBar.updatePadding(top = insets.top)
+            binding.actionsView.updatePadding(bottom = actionsViewInitialPaddingBottom + insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         binding.version.text =
             String.format(getString(R.string.version_label), BuildConfig.VERSION_NAME)

--- a/sample/src/main/java/com/sampleapp/functions/layoutinspector/DemoLayoutInspectorActivity.kt
+++ b/sample/src/main/java/com/sampleapp/functions/layoutinspector/DemoLayoutInspectorActivity.kt
@@ -1,15 +1,26 @@
 package com.sampleapp.functions.layoutinspector
 
 import android.os.Bundle
+import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import com.sampleapp.R
 import com.sampleapp.databinding.ActivityDemoLayoutInspectorBinding
 
 class DemoLayoutInspectorActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         val binding = ActivityDemoLayoutInspectorBinding.inflate(layoutInflater)
         setContentView(binding.root)
+        ViewCompat.setOnApplyWindowInsetsListener(binding.root) { v, windowInsets ->
+            val insets = windowInsets.getInsets(WindowInsetsCompat.Type.systemBars())
+            binding.appBar.updatePadding(top = insets.top)
+            v.updatePadding(left = insets.left, right = insets.right, bottom = insets.bottom)
+            WindowInsetsCompat.CONSUMED
+        }
 
         binding.close.setOnClickListener {
             finish()

--- a/sample/src/main/res/layout/activity_demo_layout_inspector.xml
+++ b/sample/src/main/res/layout/activity_demo_layout_inspector.xml
@@ -5,6 +5,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/appBg">

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -6,6 +6,7 @@
     android:layout_height="match_parent">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:id="@+id/appBar"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:background="@color/appBg">


### PR DESCRIPTION
## Summary

Adopts Android's edge-to-edge display mode throughout the Pluto library, its plugins, and the sample app. Content now draws behind the status bar and navigation bar; insets are handled explicitly via `WindowInsetsCompat` so nothing gets clipped.

---

## Changes

### `deps: add androidx-activity dependency for edge-to-edge support`
- Added `androidx.activity:activity-ktx` to the version catalog, `pluto/lib`, and `sample` — required for the `enableEdgeToEdge()` API.

### `feat: enable edge-to-edge in Pluto core activities`
- **`PlutoActivity`** — replaced legacy `WindowManager` flags and manual status-bar colour with `enableEdgeToEdge()` + `ViewCompat.setOnApplyWindowInsetsListener` applying `top`/`bottom` padding.
- **`SelectorActivity`** — same pattern; preserves the layout's initial padding so insets are additive.
- **`RulerActivity`** — adjusts the floating controls' `topMargin` instead of padding to keep the ruler widget unaffected.
- **Plugin fragment layouts** (datastore, exceptions, logger, network, rooms-database, shared-preferences, selector dialog) — removed `android:fitsSystemWindows="true"`; insets are now consumed at the activity level.

### `feat: add edge-to-edge support to layout-inspector plugin`
- **`ViewHierarchyFragment`** — calls `WindowCompat.setDecorFitsSystemWindows(false)` in `onStart` and applies insets to the app-bar top padding and list bottom padding. Added `@id/appBarContent` to the layout.
- **`ViewInfoFragment`** — removed the now-redundant manual bottom-padding insets listener for the preview bottom sheet.
- **Layout XMLs** (`view_info`, `view_hierarchy`, `view_attr`) — removed `android:fitsSystemWindows`.

**Bug fix — `InspectOverlay` coordinate mismatch under edge-to-edge:**

`enableEdgeToEdge()` + `paddingTop = statusBarHeight` on the Pluto root view shifts `InspectOverlay` down the screen. `InspectedView.reset()` was storing rects in screen-absolute coordinates (via `getLocationOnScreen`), while canvas drawing and `MotionEvent` coordinates are overlay-local — causing hit-testing and selection highlights to be offset by roughly the status-bar height.

- `InspectedView` now holds a reference to the overlay `View` and calls `overlay.getLocationOnScreen()` inside every `reset()`, subtracting the offset so all rects are in overlay-local space. Works correctly for both edge-to-edge and non-edge-to-edge inspected apps.
- `InspectOverlay.tryGetFrontView()` wraps the traversal in `doOnLayout {}` so the position is read only after the overlay's first layout pass (before layout `getLocationOnScreen` always returns `[0, 0]`).

### `feat: enable edge-to-edge in sample app activities`
- **`MainActivity`** and **`DemoLayoutInspectorActivity`** — added `enableEdgeToEdge()` and explicit inset handling (app-bar top, actions/root bottom, horizontal gutters).
- Added `@id/appBar` to both activity layouts so the inset listener can reference the correct view.

---

## Screenshots

<img width="320" alt="Screenshot_20260521_054257" src="https://github.com/user-attachments/assets/dc65a55d-fb59-4e26-b38c-a114335a9a6c" />

<img width="320" alt="Screenshot_20260521_054307" src="https://github.com/user-attachments/assets/df2e3751-316e-48e4-8428-5ac5aa209e30" />

<img width="320" alt="Screenshot_20260521_054318" src="https://github.com/user-attachments/assets/6f12ed1a-18fb-4733-b56f-0741a1c4aab8" />

<img width="320" alt="Screenshot_20260521_054342" src="https://github.com/user-attachments/assets/c29a5510-1af0-444d-be4a-8a58ea8c4d84" />

<img width="320" alt="Screenshot_20260521_055347" src="https://github.com/user-attachments/assets/44580a4b-e1be-4bb9-b7c7-7e7bcdebcb52" />
